### PR TITLE
refactor: make chains config-driven via a single CHAINS source of truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ npx hardhat run scripts/deploy.ts --network baseSepolia
 
 It deploys the pad and its `PotatoFeeLocker`, prints both addresses, and writes `deployments.baseSepolia.json`. The `PotatoPad` constructor takes `(treasury, startFdvWei, topFdvWei, antiSnipeBlocks, factory, positionManager, weth)`; the deploy script fills in the Uniswap addresses per network and the FDV/anti-snipe values from the env above.
 
-To target a different chain, add its Uniswap V3 factory, NonfungiblePositionManager, and WETH addresses to the `CANONICAL` map in `scripts/deploy.ts` and add a network entry in `hardhat.config.ts`. **Robinhood Chain mainnet (chainId 4663)** is already wired this way, and is where the live demo runs.
+To target a different chain, follow the end-to-end guide in **[docs/ADDING_A_CHAIN.md](docs/ADDING_A_CHAIN.md)**: it's three small edits (a `hardhat.config.ts` network entry, a `CANONICAL` entry in `scripts/deploy.ts`, and one entry in the frontend's `CHAINS` config). **Robinhood Chain mainnet (chainId 4663)** is already wired this way, and is where the live demo runs.
 
 ## Host the website
 
@@ -191,7 +191,7 @@ The website is a standard Next.js app, so any host that runs Next works (Vercel,
 That is it. There is **no database and no indexer to run**: the Discover feed is served by the `/api/tokens` route, which scans launch events once server-side and caches the result for all visitors; everything else is read live from the chain over RPC.
 
 Notes:
-- To point the site at mainnet or another chain, add that chain and its pad address to `web/lib/config.ts` and set the matching env var. Earlier pads for a chain can be listed as `LEGACY_PADS` so their tokens keep showing after you redeploy.
+- To point the site at mainnet or another chain, add one entry to the `CHAINS` array in `web/lib/config.ts` and set the matching env var — see **[docs/ADDING_A_CHAIN.md](docs/ADDING_A_CHAIN.md)**. Earlier pads for a chain can be listed under that entry's `legacyPads` so their tokens keep showing after you redeploy.
 - **You must keep the "Made by proofofpotato.com" footer credit** (see the license section).
 
 ## Configuration

--- a/docs/ADDING_A_CHAIN.md
+++ b/docs/ADDING_A_CHAIN.md
@@ -1,0 +1,116 @@
+# Adding a chain
+
+PotatoPad runs on any EVM chain that has a **Uniswap V3 deployment** (factory +
+NonfungiblePositionManager) and a **canonical WETH**. Adding one is three small,
+independent edits: deploy the contract, tell the deploy script where Uniswap
+lives, and tell the frontend about the new chain.
+
+Robinhood Chain mainnet (chainId `4663`) is already wired end-to-end and is the
+best worked example to copy.
+
+## What you need first
+
+- The chain's **RPC URL** and **chainId**.
+- Its **Uniswap V3 factory** and **NonfungiblePositionManager** addresses. These
+  are on [Uniswap's deployments page](https://docs.uniswap.org/contracts/v3/reference/deployments/)
+  for canonical chains, or triangulate them on-chain: a live pool's `factory()`
+  and the NPM's `factory()` / `WETH9()` should be self-consistent, and
+  `factory.feeAmountTickSpacing(10000)` must be non-zero (the 1% tier PotatoPad
+  launches into must exist).
+- Its **canonical WETH** address (verify it equals a live WETH pool's `token0`).
+- Optionally, the Uniswap **SwapRouter02** and **QuoterV2** for in-app trading,
+  and the chain's **GeckoTerminal** network slug for the embedded price chart.
+
+## 1. Contracts — deploy the pad
+
+Two edits under `contracts/`, both keyed by the Hardhat **network name**:
+
+**`contracts/hardhat.config.ts`** — add a network entry:
+
+```ts
+myChain: {
+  url: process.env.MYCHAIN_RPC_URL || "https://rpc.mychain.example",
+  chainId: 1234,
+  accounts: process.env.DEPLOYER_PRIVATE_KEY ? [process.env.DEPLOYER_PRIVATE_KEY] : [],
+},
+```
+
+**`contracts/scripts/deploy.ts`** — add the Uniswap addresses to `CANONICAL`
+under the same network name:
+
+```ts
+myChain: {
+  factory: "0x…",   // UniswapV3Factory
+  npm:     "0x…",   // NonfungiblePositionManager
+  weth:    "0x…",   // canonical WETH
+},
+```
+
+Then deploy (see the [README](../README.md#deploy-the-contracts-to-a-testnet)
+for the FDV / treasury env vars):
+
+```bash
+cd contracts
+npx hardhat run scripts/deploy.ts --network myChain
+```
+
+It prints the `PotatoPad` and `PotatoFeeLocker` addresses and writes
+`deployments.myChain.json`. Note the pad address and its **deploy block** — the
+frontend needs both.
+
+## 2. Frontend — register the chain
+
+The frontend has a **single source of truth**: the `CHAINS` array in
+[`web/lib/config.ts`](../web/lib/config.ts). Every per-chain lookup map
+(`PAD_ADDRESSES`, `WETH_ADDRESSES`, `SWAP_ROUTER_ADDRESSES`, `QUOTER_ADDRESSES`,
+`PAD_START_BLOCK`, `LEGACY_PADS`, `SUPPORTED_CHAINS`, and the Uniswap /
+GeckoTerminal slug maps) is **derived** from it, so you add exactly one entry:
+
+```ts
+{
+  chain: myChain,                                   // a viem/wagmi Chain (see below)
+  padAddress: process.env.NEXT_PUBLIC_PAD_ADDRESS_MYCHAIN,
+  weth: "0x…",
+  swapRouter: "0x…",        // optional — omit to disable in-app trading
+  quoter: "0x…",            // optional — omit to disable in-app quotes
+  padStartBlock: 1234567n,  // the pad's deploy block (log-scan start)
+  legacyPads: [],           // optional — earlier pads whose tokens still show
+  uniswapSlug: "mychain",   // optional — the "Trade on Uniswap" link slug
+  geckoTerminalNetwork: "mychain", // optional — only if GT indexes this chain
+},
+```
+
+If the chain isn't in `wagmi/chains`, define it with viem's `defineChain` first
+(the `robinhoodChain` export at the top of `config.ts` is the template) and pass
+it as `chain`. Otherwise import it from `wagmi/chains`.
+
+That is the only frontend edit. `wagmi.ts` builds its chain/transport list from
+these exports, so no separate wagmi change is needed.
+
+## 3. Environment
+
+Set the pad address env var you referenced above, matching the
+`NEXT_PUBLIC_PAD_ADDRESS_<CHAIN>` convention:
+
+```bash
+NEXT_PUBLIC_PAD_ADDRESS_MYCHAIN=0x…   # the pad from step 1
+```
+
+For a chain whose RPC key must stay server-side, add a matching `/api/rpc`
+proxy env (`MYCHAIN_RPC_URL`) — see the [README hosting section](../README.md#host-the-website).
+
+## Checklist
+
+- [ ] `contracts/hardhat.config.ts` — network entry added
+- [ ] `contracts/scripts/deploy.ts` — `CANONICAL[myChain]` added
+- [ ] Pad deployed; address + deploy block recorded
+- [ ] `web/lib/config.ts` — one `CHAINS` entry added
+- [ ] `NEXT_PUBLIC_PAD_ADDRESS_<CHAIN>` set in the frontend env
+- [ ] `npx tsc --noEmit` and `npm run build` clean in `web/`
+
+## Why the split
+
+The contract edits (`hardhat.config.ts`, `deploy.ts`) run under Node/Hardhat and
+are keyed by Hardhat network name; the frontend edit runs in the browser bundle
+and is keyed by chainId. They live in separate build graphs, so they can't share
+one module — but each side is now a single, obvious edit site.

--- a/web/lib/config.ts
+++ b/web/lib/config.ts
@@ -1,4 +1,4 @@
-import { defineChain, type Address } from "viem";
+import { defineChain, type Address, type Chain } from "viem";
 import { baseSepolia, hardhat } from "wagmi/chains";
 
 /**
@@ -25,20 +25,95 @@ function envAddress(value: string | undefined): Address {
     : ZERO_ADDRESS;
 }
 
+/** A single PotatoPad deployment: its address and the block to scan logs from. */
+export interface PadDeployment {
+  address: Address;
+  startBlock: bigint;
+}
+
+/**
+ * Everything the frontend needs to know about ONE chain, in one place. Adding a
+ * chain means adding a single entry to {CHAINS} below — every per-chain lookup
+ * map exported from this file is DERIVED from these entries, so there is exactly
+ * one edit site. See docs/ADDING_A_CHAIN.md for the end-to-end process.
+ */
+export interface ChainConfig {
+  /** The viem/wagmi chain object (id, RPC, explorer). */
+  chain: Chain;
+  /**
+   * The primary (write) PotatoPad address, read from a public env var so the
+   * same build can target different deployments. Zero/undefined = not deployed.
+   */
+  padAddress?: string;
+  /** Canonical WETH the single-sided LP pairs against (locker pays fees in WETH). */
+  weth: Address;
+  /** Uniswap SwapRouter02 for in-app buy/sell. Omit to disable the in-app router. */
+  swapRouter?: Address;
+  /** Uniswap QuoterV2 for accurate buy/sell estimates. Omit to disable in-app quotes. */
+  quoter?: Address;
+  /** Block to start scanning pad event logs from (the pad's deploy block). */
+  padStartBlock: bigint;
+  /** Read-only pads from EARLIER deploys that still custody launched tokens. */
+  legacyPads?: PadDeployment[];
+  /** Uniswap interface chain slug, for the "Trade on Uniswap" link. */
+  uniswapSlug?: string;
+  /** GeckoTerminal network slug, for the embedded pool chart (only GT-indexed chains). */
+  geckoTerminalNetwork?: string;
+}
+
+/**
+ * SINGLE SOURCE OF TRUTH for supported chains. To add a chain, append one entry
+ * here (and deploy the pad + wire contracts/ — see docs/ADDING_A_CHAIN.md). The
+ * derived maps below need no edits.
+ */
+export const CHAINS: ChainConfig[] = [
+  {
+    chain: robinhoodChain,
+    padAddress: process.env.NEXT_PUBLIC_PAD_ADDRESS_ROBINHOOD,
+    // Verified on-chain (a live Uniswap pool's token0) and in Robinhood's docs.
+    weth: "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73",
+    // Only Robinhood is wired for in-app trading (router + quoter present).
+    swapRouter: "0xcaf681a66d020601342297493863e78c959e5cb2",
+    quoter: "0x33e885ed0ec9bf04ecfb19341582aadcb4c8a9e7",
+    padStartBlock: 11_555_000n, // deploy block of the CREATE2 pad 0x12A0…D91F
+    legacyPads: [
+      // v2 pad (pre-CREATE2 fix). Still holds CHIP + anything launched on it.
+      { address: "0xc12723c251dABcBe10c4F44060A6AE6b5E96a79d", startBlock: 11_481_181n },
+    ],
+    uniswapSlug: "robinhood",
+    geckoTerminalNetwork: "robinhood",
+  },
+  {
+    chain: baseSepolia,
+    padAddress: process.env.NEXT_PUBLIC_PAD_ADDRESS_BASE_SEPOLIA,
+    weth: "0x4200000000000000000000000000000000000006",
+    padStartBlock: 0n,
+    uniswapSlug: "base_sepolia",
+    // NB: base-sepolia is NOT indexed by GeckoTerminal (404s), so no chart network.
+  },
+  {
+    chain: hardhat,
+    padAddress: process.env.NEXT_PUBLIC_PAD_ADDRESS_LOCALHOST,
+    weth: envAddress(process.env.NEXT_PUBLIC_WETH_ADDRESS_LOCALHOST),
+    padStartBlock: 0n, // fresh local chain scans from genesis
+  },
+];
+
+/** Look up a chain's config by id (undefined for unsupported chains). */
+function configFor(chainId: number): ChainConfig | undefined {
+  return CHAINS.find((c) => c.chain.id === chainId);
+}
+
+/** Build a `Record<chainId, T>` from each chain's config in one place. */
+function byChain<T>(pick: (c: ChainConfig) => T): Record<number, T> {
+  return Object.fromEntries(CHAINS.map((c) => [c.chain.id, pick(c)]));
+}
+
 /** PotatoPad contract address per chain (zero address = not deployed). */
-export const PAD_ADDRESSES: Record<number, Address> = {
-  [baseSepolia.id]: envAddress(process.env.NEXT_PUBLIC_PAD_ADDRESS_BASE_SEPOLIA),
-  [hardhat.id]: envAddress(process.env.NEXT_PUBLIC_PAD_ADDRESS_LOCALHOST),
-  [robinhoodChain.id]: envAddress(process.env.NEXT_PUBLIC_PAD_ADDRESS_ROBINHOOD),
-};
+export const PAD_ADDRESSES: Record<number, Address> = byChain((c) => envAddress(c.padAddress));
 
 /** Canonical WETH per chain (single-sided LP pairs token/WETH; locker pays fees in WETH). */
-export const WETH_ADDRESSES: Record<number, Address> = {
-  [baseSepolia.id]: "0x4200000000000000000000000000000000000006",
-  [hardhat.id]: envAddress(process.env.NEXT_PUBLIC_WETH_ADDRESS_LOCALHOST),
-  // Verified on-chain (a live Uniswap pool's token0) and in Robinhood's docs.
-  [robinhoodChain.id]: "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73",
-};
+export const WETH_ADDRESSES: Record<number, Address> = byChain((c) => c.weth);
 
 /**
  * Uniswap V3 1% fee tier — the tier every PotatoPad pool is launched into.
@@ -51,18 +126,14 @@ export const POOL_FEE_TIER = 10_000;
  * for in-app trading; other chains are `undefined`, which disables the router
  * path and falls back to the "Trade on Uniswap" link.
  */
-export const SWAP_ROUTER_ADDRESSES: Record<number, Address | undefined> = {
-  [robinhoodChain.id]: "0xcaf681a66d020601342297493863e78c959e5cb2",
-};
+export const SWAP_ROUTER_ADDRESSES: Record<number, Address | undefined> = byChain((c) => c.swapRouter);
 
 /**
  * Uniswap QuoterV2 per chain, for accurate buy/sell output estimates that
  * account for the single-sided pool's price impact. Optional — a missing quote
  * disables the in-app trade button (the Uniswap link still works).
  */
-export const QUOTER_ADDRESSES: Record<number, Address | undefined> = {
-  [robinhoodChain.id]: "0x33e885ed0ec9bf04ecfb19341582aadcb4c8a9e7",
-};
+export const QUOTER_ADDRESSES: Record<number, Address | undefined> = byChain((c) => c.quoter);
 
 /**
  * Block to start scanning pad event logs from, per chain. Live RPCs cap
@@ -70,29 +141,14 @@ export const QUOTER_ADDRESSES: Record<number, Address | undefined> = {
  * pad's deploy block forward in chunks rather than from genesis. 0 = genesis
  * (fine for a fresh local chain). UPDATE the live value when you redeploy the pad.
  */
-export const PAD_START_BLOCK: Record<number, bigint> = {
-  [robinhoodChain.id]: 11_555_000n, // deploy block of the CREATE2 pad 0x12A0…D91F
-  [baseSepolia.id]: 0n,
-  [hardhat.id]: 0n,
-};
-
-/** A single PotatoPad deployment: its address and the block to scan logs from. */
-export interface PadDeployment {
-  address: Address;
-  startBlock: bigint;
-}
+export const PAD_START_BLOCK: Record<number, bigint> = byChain((c) => c.padStartBlock);
 
 /**
  * Read-only pads from EARLIER deploys that still custody launched tokens. The
  * primary (write) pad lives in {PAD_ADDRESSES} via env; these are historical,
  * hard-coded address constants so their tokens keep showing after a repoint.
  */
-export const LEGACY_PADS: Record<number, PadDeployment[]> = {
-  [robinhoodChain.id]: [
-    // v2 pad (pre-CREATE2 fix). Still holds CHIP + anything launched on it.
-    { address: "0xc12723c251dABcBe10c4F44060A6AE6b5E96a79d", startBlock: 11_481_181n },
-  ],
-};
+export const LEGACY_PADS: Record<number, PadDeployment[]> = byChain((c) => c.legacyPads ?? []);
 
 /**
  * Every pad to READ for a chain when discovering / resolving tokens: the primary
@@ -116,19 +172,15 @@ export function padDeployments(chainId: number): PadDeployment[] {
   return out;
 }
 
-export const SUPPORTED_CHAINS = [robinhoodChain, baseSepolia, hardhat] as const;
+export const SUPPORTED_CHAINS = CHAINS.map((c) => c.chain);
 
 export function chainName(chainId: number): string {
-  const chain = SUPPORTED_CHAINS.find((c) => c.id === chainId);
-  return chain?.name ?? `chain ${chainId}`;
+  return configFor(chainId)?.chain.name ?? `chain ${chainId}`;
 }
 
 /** Block-explorer base URL for a chain, if it has one (local Hardhat does not). */
 export function explorerBaseUrl(chainId: number): string | undefined {
-  const chain = SUPPORTED_CHAINS.find((c) => c.id === chainId);
-  return chain && "blockExplorers" in chain
-    ? chain.blockExplorers?.default?.url
-    : undefined;
+  return configFor(chainId)?.chain.blockExplorers?.default?.url;
 }
 
 export function txUrl(chainId: number, hash: string): string | undefined {
@@ -141,11 +193,13 @@ export function addressUrl(chainId: number, address: string): string | undefined
   return base ? `${base}/address/${address}` : undefined;
 }
 
-/** Uniswap interface chain slugs, for the "Trade on Uniswap" link. */
+/**
+ * Uniswap interface chain slugs, for the "Trade on Uniswap" link. Derived from
+ * {CHAINS}, plus a few extra live networks a token could be bridged/traded on.
+ */
 const UNISWAP_CHAIN_SLUGS: Record<number, string> = {
-  4663: "robinhood",
-  8453: "base",
-  84532: "base_sepolia",
+  8453: "base", // base mainnet — not a launch chain, but a valid Uniswap target
+  ...byChain((c) => c.uniswapSlug),
 };
 
 export function uniswapSwapUrl(token: string, chainId?: number): string {
@@ -158,6 +212,7 @@ export function uniswapSwapUrl(token: string, chainId?: number): string {
  * v2 token is live on Uniswap V3 from launch, so its pool is charted directly.
  * Only live, GT-indexed networks belong here — testnets and local chains 404
  * (verified: `base-sepolia` is not indexed) and fall back to a placeholder.
+ * Derived from {CHAINS}, plus common L1/L2s a bridged token could chart on.
  * Full slug list: GET api.geckoterminal.com/api/v2/networks
  */
 export const GECKOTERMINAL_NETWORKS: Record<number, string> = {
@@ -165,7 +220,7 @@ export const GECKOTERMINAL_NETWORKS: Record<number, string> = {
   10: "optimism",
   8453: "base",
   42161: "arbitrum",
-  4663: "robinhood",
+  ...byChain((c) => c.geckoTerminalNetwork),
 };
 
 export function geckoTerminalPoolUrl(chainId: number, pool: string): string | undefined {


### PR DESCRIPTION
## What does this PR do?

Makes the frontend chain configuration data-driven: a single `CHAINS` array in `web/lib/config.ts` becomes the source of truth, and every per-chain lookup map is derived from it, so adding a chain is one obvious entry instead of ~7 parallel edits. Also adds `docs/ADDING_A_CHAIN.md` documenting the full end-to-end process. Closes #11.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / cleanup
- [x] Docs
- [ ] Security fix

## Checklist

- [x] `contracts/`: `npx hardhat test` passes (added/updated tests for new behavior) — no contract changes in this PR; the suite stays green
- [x] `web/`: `npx tsc --noEmit` is clean and `npm run build` succeeds
- [x] Focused on one concern; no unrelated changes
- [x] No secrets, private keys, or `.env*` files committed
- [x] No hidden owner powers / rug vectors introduced; keeps the "Made by proofofpotato.com" credit
- [x] Description explains the *why*, not just the *what*

## Anything reviewers should look at closely?

The refactor is meant to be **behavior-preserving** — the derived maps (`PAD_ADDRESSES`, `WETH_ADDRESSES`, `SWAP_ROUTER_ADDRESSES`, `QUOTER_ADDRESSES`, `PAD_START_BLOCK`, `LEGACY_PADS`, `SUPPORTED_CHAINS`, and the Uniswap / GeckoTerminal slug maps) reproduce the previous values exactly. Worth confirming the two slug maps in particular, since they intentionally keep a few extra non-launch networks (e.g. `base`, `eth`, `optimism`, `arbitrum`) on top of the `CHAINS`-derived entries.

One deliberate design choice: the contract-side edits (`hardhat.config.ts`, `scripts/deploy.ts`) are **not** merged with the frontend config. They run in different build graphs (Hardhat/Node keyed by network name vs. browser bundle keyed by chainId) and can't share a module without extra tooling — so the guide documents both sides instead.
