### PR TITLE
feat: match tokens by contract address in Discover search

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -82,8 +82,14 @@ export default function DiscoverPage() {
     const q = query.trim().toLowerCase();
     let list = rows;
     if (q) {
+      // When the query looks like an address (0x…), also match tokens by their
+      // contract address (prefix), so pasting an address filters straight to it.
+      const isAddressQuery = q.startsWith("0x");
       list = list.filter(
-        (r) => r.name.toLowerCase().includes(q) || r.symbol.toLowerCase().includes(q),
+        (r) =>
+          r.name.toLowerCase().includes(q) ||
+          r.symbol.toLowerCase().includes(q) ||
+          (isAddressQuery && r.address.toLowerCase().startsWith(q)),
       );
     }
     switch (tab) {


### PR DESCRIPTION
## What does this PR do?

Extends the Discover search so a query that looks like an address (starts with `0x`) also matches tokens by their contract address (prefix), in addition to name/symbol. Pasting a token address now filters the feed straight to it. Closes #4.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Security fix

## Checklist

- [x] `contracts/`: `npx hardhat test` passes (added/updated tests for new behavior) — no contract changes
- [x] `web/`: `npx tsc --noEmit` is clean and `npm run build` succeeds
- [x] Focused on one concern; no unrelated changes
- [x] No secrets, private keys, or `.env*` files committed
- [x] No hidden owner powers / rug vectors introduced; keeps the "Made by proofofpotato.com" credit
- [x] Description explains the *why*, not just the *what*

## Anything reviewers should look at closely?

The `0x` guard means normal text queries never hit the address branch, so name/symbol search is unchanged. Address matching is a case-insensitive `startsWith` on the token address, so both a full address and a leading fragment filter correctly.
