### PR TITLE
fix: global rate-limit backstop (spoofable X-Forwarded-For bypasses per-IP cap)

### DIFF
--- a/web/app/api/rpc/route.ts
+++ b/web/app/api/rpc/route.ts
@@ -46,9 +46,29 @@ const BLOCKED_METHODS = new Set([
 // Coarse per-IP sliding-window limiter (in-memory; nodejs runtime keeps it warm).
 // Sized for the app's own read bursts (multi-pad log scans + multicalls) while
 // still capping outright abuse.
+//
+// NOTE: the per-IP key comes from `x-forwarded-for` / `x-real-ip`, which are
+// client-settable. Unless a fixed upstream proxy (Railway/Cloudflare) is
+// guaranteed to overwrite them, a caller can rotate the header per request and
+// evade the per-IP cap entirely. So the per-IP limit is only a soft signal; the
+// GLOBAL backstop below is the unspoofable ceiling that actually protects the
+// shared Alchemy key from being drained by header rotation.
 const WINDOW_MS = 10_000;
 const MAX_PER_WINDOW = 500;
 const hits = new Map<string, number[]>();
+
+// Global backstop across ALL callers — independent of the (spoofable) IP key.
+// Generous enough for real concurrent traffic (~10x a single heavy client) but
+// a hard cap on outright abuse. Tune via env for multi-instance deploys.
+const MAX_GLOBAL_PER_WINDOW = Number(process.env.RPC_MAX_GLOBAL_PER_WINDOW) || 5_000;
+let globalHits: number[] = [];
+
+function globalRateLimited(): boolean {
+  const now = Date.now();
+  globalHits = globalHits.filter((t) => now - t < WINDOW_MS);
+  globalHits.push(now);
+  return globalHits.length > MAX_GLOBAL_PER_WINDOW;
+}
 
 function rateLimited(ip: string): boolean {
   const now = Date.now();
@@ -99,7 +119,8 @@ export async function POST(req: NextRequest) {
     req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
     req.headers.get("x-real-ip") ||
     "unknown";
-  if (rateLimited(ip)) {
+  // Global backstop first (unspoofable), then the soft per-IP cap.
+  if (globalRateLimited() || rateLimited(ip)) {
     return NextResponse.json({ error: "rate limited" }, { status: 429 });
   }
 

--- a/web/app/api/upload/route.ts
+++ b/web/app/api/upload/route.ts
@@ -18,9 +18,24 @@ const ALLOWED_TYPES = new Set([
   "image/svg+xml",
 ]);
 
+// NOTE: the per-IP key is derived from `x-forwarded-for` / `x-real-ip`, which
+// are client-settable. Unless a fixed upstream proxy overwrites them, a caller
+// can rotate the header per request and evade this cap, burning the Pinata
+// quota. The GLOBAL backstop below is the unspoofable ceiling.
 const WINDOW_MS = 60_000;
 const MAX_PER_WINDOW = 20;
 const hits = new Map<string, number[]>();
+
+// Global backstop across ALL callers — independent of the (spoofable) IP key.
+const MAX_GLOBAL_PER_WINDOW = Number(process.env.UPLOAD_MAX_GLOBAL_PER_WINDOW) || 200;
+let globalHits: number[] = [];
+
+function globalRateLimited(): boolean {
+  const now = Date.now();
+  globalHits = globalHits.filter((t) => now - t < WINDOW_MS);
+  globalHits.push(now);
+  return globalHits.length > MAX_GLOBAL_PER_WINDOW;
+}
 
 function rateLimited(ip: string): boolean {
   const now = Date.now();
@@ -46,7 +61,8 @@ export async function POST(req: NextRequest) {
     req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
     req.headers.get("x-real-ip") ||
     "unknown";
-  if (rateLimited(ip)) {
+  // Global backstop first (unspoofable), then the soft per-IP cap.
+  if (globalRateLimited() || rateLimited(ip)) {
     return NextResponse.json({ error: "rate limited" }, { status: 429 });
   }
 


### PR DESCRIPTION
## Problem

Both `/api/rpc` and `/api/upload` rate-limit by an IP derived from
`x-forwarded-for` / `x-real-ip`:

```ts
const ip =
  req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
  req.headers.get("x-real-ip") || "unknown";
```

Those headers are **client-settable**. Unless a fixed upstream proxy
(Railway/Cloudflare) is guaranteed to overwrite them, a caller can send a
different `X-Forwarded-For` on every request and get a fresh limiter bucket
each time — bypassing the per-IP cap entirely. On a single instance with no
CDN in front that makes the shared Alchemy key (RPC proxy) and the Pinata
quota (upload) effectively unmetered.

## Fix

Add an **unspoofable global sliding-window backstop** across all callers,
checked before the per-IP cap. The per-IP limit stays as a soft signal;
the global cap is the real ceiling that header rotation can't evade.

- `/api/rpc`: global cap `RPC_MAX_GLOBAL_PER_WINDOW` (default 5,000 / 10s) —
  ~10x a single heavy client, so normal multi-user traffic is unaffected.
- `/api/upload`: global cap `UPLOAD_MAX_GLOBAL_PER_WINDOW` (default 200 / 60s).

Both are env-tunable. Legitimate per-IP behavior is unchanged. For a
multi-instance deploy a shared store (Redis) is still the durable answer;
this closes the trivial single-instance bypass without new dependencies.

Found via an AntFleet two-model security review of a benchmark fork of this repo.
