### PR TITLE
fix: add swap deadline via SwapRouter02 multicall (close MEV/mempool window)

### DIFF
--- a/web/components/TradeWidget.tsx
+++ b/web/components/TradeWidget.tsx
@@ -2,7 +2,7 @@
 
 import { ExternalLink, TrendingUp } from "lucide-react";
 import { useState } from "react";
-import { formatEther, parseEther, type Address } from "viem";
+import { encodeFunctionData, formatEther, parseEther, type Address } from "viem";
 import { useAccount, useBalance, useReadContract } from "wagmi";
 import { potatoTokenAbi } from "@/lib/abi";
 import {
@@ -21,6 +21,19 @@ import { TxStatus } from "@/components/TxStatus";
 
 /** Keep a little ETH aside for gas when quick-filling "Max" on buys. */
 const GAS_BUFFER = parseEther("0.01");
+
+/**
+ * How long a signed swap stays valid, in seconds. SwapRouter02's
+ * `exactInputSingle` struct has no deadline, so a signed-but-unmined swap would
+ * otherwise linger in the mempool indefinitely (bounded only by slippage) and
+ * be executed later when it's sandwich-profitable. We wrap the call in the
+ * router's `multicall(deadline, [...])`, which reverts once the deadline passes.
+ */
+const SWAP_DEADLINE_SECONDS = 600n; // 10 minutes
+
+function swapDeadline(): bigint {
+  return BigInt(Math.floor(Date.now() / 1000)) + SWAP_DEADLINE_SECONDS;
+}
 
 const SLIPPAGE_OPTIONS: Array<{ label: string; bps: bigint }> = [
   { label: "1%", bps: 100n },
@@ -145,8 +158,7 @@ export function TradeWidget({
 
   function onBuy() {
     if (amount === undefined || !user || minOut === 0n || !router) return;
-    buyTx.writeContract({
-      address: router,
+    const swapData = encodeFunctionData({
       abi: swapRouter02Abi,
       functionName: "exactInputSingle",
       args: [
@@ -160,6 +172,13 @@ export function TradeWidget({
           sqrtPriceLimitX96: 0n,
         },
       ],
+    });
+    // Wrap in the deadline-checked multicall so the tx can't be mined late.
+    buyTx.writeContract({
+      address: router,
+      abi: swapRouter02Abi,
+      functionName: "multicall",
+      args: [swapDeadline(), [swapData]],
       value: amount,
     });
   }
@@ -176,8 +195,7 @@ export function TradeWidget({
 
   function onSell() {
     if (amount === undefined || !user || minOut === 0n || !router || exceedsBalance) return;
-    sellTx.writeContract({
-      address: router,
+    const swapData = encodeFunctionData({
       abi: swapRouter02Abi,
       functionName: "exactInputSingle",
       args: [
@@ -191,6 +209,13 @@ export function TradeWidget({
           sqrtPriceLimitX96: 0n,
         },
       ],
+    });
+    // Wrap in the deadline-checked multicall so the tx can't be mined late.
+    sellTx.writeContract({
+      address: router,
+      abi: swapRouter02Abi,
+      functionName: "multicall",
+      args: [swapDeadline(), [swapData]],
     });
   }
 

--- a/web/lib/pool.ts
+++ b/web/lib/pool.ts
@@ -77,7 +77,14 @@ export const erc20BalanceAbi = [
   },
 ] as const;
 
-/** SwapRouter02 exactInputSingle (no deadline in the "02" struct). */
+/**
+ * SwapRouter02 `exactInputSingle` (no `deadline` in the "02" struct) plus the
+ * deadline-checked `multicall(uint256 deadline, bytes[] data)`. Wrapping a single
+ * `exactInputSingle` call in `multicall(deadline, [...])` reverts once
+ * `block.timestamp > deadline`, so a signed-but-unmined swap can't be held in
+ * the mempool and executed later at a sandwich-profitable moment. `multicall` is
+ * `payable` and delegatecalls each entry, so native-ETH buys behave identically.
+ */
 export const swapRouter02Abi = [
   {
     inputs: [
@@ -98,6 +105,16 @@ export const swapRouter02Abi = [
     ],
     name: "exactInputSingle",
     outputs: [{ internalType: "uint256", name: "amountOut", type: "uint256" }],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "uint256", name: "deadline", type: "uint256" },
+      { internalType: "bytes[]", name: "data", type: "bytes[]" },
+    ],
+    name: "multicall",
+    outputs: [{ internalType: "bytes[]", name: "", type: "bytes[]" }],
     stateMutability: "payable",
     type: "function",
   },


### PR DESCRIPTION
## Problem

In-app swaps call SwapRouter02's `exactInputSingle` directly. That struct has
**no `deadline` field**, so a signed-but-unmined buy/sell can sit in the mempool
arbitrarily long and be executed later, whenever it's sandwich-profitable —
bounded only by `amountOutMinimum` (slippage). The widget offers a 10% slippage
tier on low-liquidity single-sided pools, which is a wide window for that.

## Fix

Wrap each swap in the router's deadline-checked
`multicall(uint256 deadline, bytes[] data)` (10-minute deadline). It reverts
once `block.timestamp > deadline`, closing the late-execution window.

- `multicall` is `payable` and `delegatecall`s each entry, so native-ETH buys
  (`value == amountIn`, no dust to refund) behave **identically** — only the
  ability to mine the tx late is removed.
- `exactInputSingle` calldata is built with viem's `encodeFunctionData` and
  passed as the single multicall entry; `amountOutMinimum` / slippage are
  unchanged.

Adds `multicall` to the local `swapRouter02Abi` and routes `onBuy` / `onSell`
through it.

Found via an AntFleet two-model security review of a benchmark fork of this repo.
