### PR TITLE
fix(web): Discover token image thumbnails (#1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ web/next-env.d.ts
 .env.local
 *.log
 .DS_Store
+
+# OMC local artifacts
+.omc/

--- a/web/components/TokenAvatar.tsx
+++ b/web/components/TokenAvatar.tsx
@@ -1,12 +1,16 @@
 "use client";
 
-import { resolveImageUri } from "@/lib/format";
+import { useMemo, useState } from "react";
+import { imageUriCandidates } from "@/lib/format";
 import { PotatoLogo } from "@/components/PotatoLogo";
 
 /**
  * Token avatar. If the launch supplied an `imageURI`, it's layered over a warm
  * generated potato tile — so a broken/blank image transparently falls back to
  * the generated look (the <img> hides itself on error, revealing the tile).
+ *
+ * IPFS URIs walk a small gateway list ({@link imageUriCandidates}) so a single
+ * dead public gateway (e.g. ipfs.io) does not blank every Discover thumbnail.
  */
 function hashAddress(address: string): number {
   let h = 0;
@@ -22,6 +26,36 @@ const SIZES = {
   md: { box: "h-12 w-12", icon: "h-7 w-7" },
   lg: { box: "h-14 w-14", icon: "h-8 w-8" },
 } as const;
+
+/**
+ * Isolated image layer so gateway-retry state remounts cleanly when
+ * `address` / `imageURI` change (keyed from the parent). Avoids a one-frame
+ * flash where the previous retry index is applied to a new candidate list.
+ */
+function TokenAvatarImage({ imageURI }: { imageURI?: string }) {
+  const candidates = useMemo(() => imageUriCandidates(imageURI), [imageURI]);
+  const [srcIndex, setSrcIndex] = useState(0);
+  const src = srcIndex < candidates.length ? candidates[srcIndex] : undefined;
+
+  if (!src) return null;
+
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      key={src}
+      src={src}
+      alt=""
+      className="absolute inset-0 h-full w-full object-cover"
+      loading="lazy"
+      decoding="async"
+      referrerPolicy="no-referrer"
+      onError={() => {
+        // Try the next gateway / candidate; when exhausted, only the tile shows.
+        setSrcIndex((i) => i + 1);
+      }}
+    />
+  );
+}
 
 export function TokenAvatar({
   address,
@@ -45,7 +79,6 @@ export function TokenAvatar({
   const light2 = 15 + ((h >> 20) % 12); // 15–26
   const angle = h % 360;
   const { box, icon } = SIZES[size];
-  const src = resolveImageUri(imageURI);
 
   return (
     <div
@@ -56,18 +89,10 @@ export function TokenAvatar({
       aria-hidden
     >
       <PotatoLogo className={`${icon} text-amber-200 drop-shadow-sm`} />
-      {src && (
-        // eslint-disable-next-line @next/next/no-img-element
-        <img
-          src={src}
-          alt=""
-          className="absolute inset-0 h-full w-full object-cover"
-          loading="lazy"
-          onError={(e) => {
-            (e.currentTarget as HTMLImageElement).style.display = "none";
-          }}
-        />
-      )}
+      <TokenAvatarImage
+        key={`${address.toLowerCase()}|${imageURI ?? ""}`}
+        imageURI={imageURI}
+      />
     </div>
   );
 }

--- a/web/components/TokenCard.tsx
+++ b/web/components/TokenCard.tsx
@@ -35,7 +35,13 @@ export function TokenCard({ row }: { row: TokenRow }) {
       className="card block p-5 transition-colors hover:border-amber-500/40"
     >
       <div className="flex items-center gap-3">
-        <TokenAvatar address={row.address} symbol={row.symbol} imageURI={row.imageURI} />
+        {/* Thumbnail: resolves ipfs:// via public gateways; broken URLs fall back to a potato tile */}
+        <TokenAvatar
+          address={row.address}
+          symbol={row.symbol}
+          imageURI={row.imageURI}
+          size="md"
+        />
         <div className="flex min-w-0 flex-1 items-baseline gap-1.5">
           <h3 className="truncate font-bold text-neutral-100">{row.name}</h3>
           <span className="shrink-0 font-mono text-xs text-neutral-500">${row.symbol}</span>

--- a/web/lib/format.ts
+++ b/web/lib/format.ts
@@ -105,13 +105,153 @@ export function formatUsdPrice(n: number): string {
   return `$${n.toPrecision(2)}`;
 }
 
-/** Resolve an image URI for use in `<img src>`: rewrites ipfs:// to a public
- *  gateway, passes http(s)/data through, and drops anything else (safety). */
-export function resolveImageUri(uri: string | undefined): string | undefined {
-  if (!uri) return undefined;
+/**
+ * Public IPFS gateways tried in order for launch images.
+ *
+ * Pinata is first: `/api/upload` pins via Pinata, and `ipfs.io` is often slow
+ * or blocked for browsers. Remaining gateways are fallbacks for CIDs pinned
+ * elsewhere (or when Pinata is temporarily unreachable).
+ */
+const IPFS_GATEWAYS = [
+  "https://gateway.pinata.cloud/ipfs/",
+  "https://ipfs.io/ipfs/",
+  "https://dweb.link/ipfs/",
+] as const;
+
+/**
+ * CIDv0: Base58btc, case-sensitive (must not allow I/O/l via /i fold).
+ * CIDv1: multibase `b` + base32 (lowercase a-z / 2-7), e.g. bafy… / bafk… / bafz…
+ */
+const CID_V0_RE = /^Qm[1-9A-HJ-NP-Za-km-z]{44}$/;
+const CID_V1_RE = /^baf[a-z2-7]{20,}$/;
+
+function isCid(seg: string): boolean {
+  return CID_V0_RE.test(seg) || CID_V1_RE.test(seg);
+}
+
+/** Strip query/fragment so they never become path bytes. */
+function stripQueryFragment(s: string): string {
+  const q = s.search(/[?#]/);
+  return q === -1 ? s : s.slice(0, q);
+}
+
+/**
+ * Fully decode a path segment (bounded) and reject dot-segments or any
+ * decoded path separator. Nested encodings like `%252e%252e` are unwrapped
+ * until stable; `%2e%2e%2fadmin` expands to `../admin` and is rejected.
+ */
+function isSafePathSegment(seg: string): boolean {
+  if (!seg || seg === "." || seg === "..") return false;
+  if (/[\u0000-\u001f\u007f\\]/.test(seg)) return false;
+
+  let cur = seg;
+  for (let i = 0; i < 4; i++) {
+    let next: string;
+    try {
+      next = decodeURIComponent(cur);
+    } catch {
+      return false;
+    }
+    if (
+      next === "." ||
+      next === ".." ||
+      next.includes("/") ||
+      next.includes("\\") ||
+      /[\u0000-\u001f\u007f]/.test(next)
+    ) {
+      return false;
+    }
+    if (next === cur) return true; // fully decoded and clean
+    cur = next;
+  }
+  // Still changing after the decode budget → reject.
+  return false;
+}
+
+/**
+ * Sanitize an IPFS content path: first segment must be a CID; reject dot
+ * segments, separators, and control characters so rebuilt gateway URLs stay
+ * under `/ipfs/<cid>/…`. Path kept as-is (no whole-path decode) so remounts
+ * preserve encoding on alternate gateways.
+ */
+function sanitizeIpfsPath(path: string): string | undefined {
+  const cleaned = stripQueryFragment(path).replace(/^\/+/, "");
+  if (!cleaned) return undefined;
+
+  // Reject control chars and backslash before splitting.
+  if (/[\u0000-\u001f\u007f\\]/.test(cleaned)) return undefined;
+
+  const segments = cleaned.split("/");
+  if (!isCid(segments[0])) return undefined;
+
+  for (let i = 1; i < segments.length; i++) {
+    if (!isSafePathSegment(segments[i])) return undefined;
+  }
+
+  return cleaned;
+}
+
+/**
+ * Extract an IPFS content path (CID + optional subpath) from common URI forms.
+ * Returns undefined when the input is not a safe IPFS path.
+ */
+function extractIpfsPath(uri: string): string | undefined {
   const t = uri.trim();
   if (!t) return undefined;
-  if (t.startsWith("ipfs://")) return `https://ipfs.io/ipfs/${t.slice("ipfs://".length)}`;
-  if (/^(https?:|data:image\/)/i.test(t)) return t;
-  return undefined;
+
+  // Schemes are case-insensitive (IPFS://CID is valid).
+  if (/^ipfs:\/\//i.test(t)) {
+    // ipfs://CID… | ipfs:///ipfs/CID… | ipfs://ipfs/CID…
+    // Drop query/fragment before path validation.
+    let path = stripQueryFragment(t.replace(/^ipfs:\/\//i, "")).replace(/^\/+/, "");
+    if (path.toLowerCase().startsWith("ipfs/")) path = path.slice(5);
+    return sanitizeIpfsPath(path);
+  }
+
+  // Already on a gateway: https://<host>/ipfs/<path>[?query][#frag]
+  const gateway = t.match(/^https?:\/\/[^/]+\/ipfs\/(.+)$/i);
+  if (gateway?.[1]) return sanitizeIpfsPath(gateway[1]);
+
+  // Bare CID or CID/subpath (query/fragment stripped inside sanitize).
+  return sanitizeIpfsPath(t);
+}
+
+/**
+ * Ordered list of browser-loadable image URLs for a launch `imageURI`.
+ * Callers that only need one URL should use {@link resolveImageUri}.
+ * Avatars that want resilience can walk the list on `<img onError>`.
+ */
+export function imageUriCandidates(uri: string | undefined | null): string[] {
+  if (uri == null) return [];
+  const t = uri.trim();
+  if (!t) return [];
+
+  // data: only for images — never data:text/html etc.
+  if (/^data:image\//i.test(t)) return [t];
+
+  const ipfsPath = extractIpfsPath(t);
+  if (ipfsPath) {
+    const out: string[] = [];
+    // Prefer the original https gateway URL first if the creator already pinned
+    // a full URL (keeps working mirrors / private gateways they chose).
+    if (/^https?:\/\//i.test(t)) out.push(t);
+    for (const base of IPFS_GATEWAYS) {
+      const candidate = `${base}${ipfsPath}`;
+      if (!out.includes(candidate)) out.push(candidate);
+    }
+    return out;
+  }
+
+  // Plain http(s) image URLs (and non-image pages that will fail → fallback tile).
+  if (/^https?:\/\//i.test(t)) return [t];
+
+  // Drop javascript:, data:text/*, bare junk, etc.
+  return [];
+}
+
+/** Resolve an image URI for use in `<img src>`: rewrites ipfs:// (and bare
+ *  CIDs / gateway URLs) to a public gateway, passes http(s)/data:image through,
+ *  and drops anything else (safety). */
+export function resolveImageUri(uri: string | undefined | null): string | undefined {
+  return imageUriCandidates(uri)[0];
 }


### PR DESCRIPTION
## Summary

- Resolves Discover token images for `ipfs://` launch metadata by rewriting through reliable public gateways (Pinata first — matches `/api/upload` pins; `ipfs.io` / `dweb.link` as fallbacks).
- `TokenAvatar` walks the gateway list on `<img onError>` and falls back to the generated potato tile when every candidate fails.
- Hardens `resolveImageUri` / new `imageUriCandidates`: CID validation, path-traversal rejection, query/fragment strip, unsafe schemes dropped.

Fixes #1

## Root cause

`TokenCard` already passed `imageURI` into `TokenAvatar`, but `resolveImageUri` only used `https://ipfs.io/ipfs/…`. Live potato.fm CIDs load via Pinata; `ipfs.io` often fails, so cards looked empty.

## Test plan

- [x] `cd web && npx tsc --noEmit`
- [x] `cd web && npm run build`
- [x] Manual: known live CIDs return 200 from `gateway.pinata.cloud`
- [ ] On preview/local: Discover cards with `ipfs://` images show logos; tokens without images show potato tile; broken URLs fall back cleanly

## Audit

Three `omc ask codex` review rounds on this change — **0 Critical / High / Medium** each time (final round: 0 findings of any severity).

## Attribution

Keeps the existing "Made by proofofpotato.com" footer credit (no UI chrome change beyond thumbnails).