### PR TITLE
feat(web): show + claim creator token-side LP fees (#3)

### DIFF
--- a/web/app/token/[address]/page.tsx
+++ b/web/app/token/[address]/page.tsx
@@ -134,6 +134,7 @@ export default function TokenPage() {
           creator={creator}
           lpTokenId={lpTokenId}
           pool={pool}
+          token={token}
           symbol={symbol}
           pad={resolved.pad}
         />

--- a/web/components/HarvestCard.tsx
+++ b/web/components/HarvestCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Coins, Leaf, Lock } from "lucide-react";
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { Address } from "viem";
 import { useAccount, useReadContract } from "wagmi";
 import { potatoFeeLockerAbi, potatoPadAbi } from "@/lib/abi";
@@ -12,6 +12,20 @@ import { useAccruedFees } from "@/lib/pool";
 import { AddressChip } from "@/components/AddressChip";
 import { TxStatus } from "@/components/TxStatus";
 
+type ClaimAsset = "weth" | "token";
+
+/**
+ * Orchestration for collect → ordered claims. One machine owns the whole flow so
+ * latched receipt flags from a prior claim cannot re-fire claims later, and
+ * independent claimable refetches cannot start the wrong asset first.
+ */
+type FeeFlow =
+  | { kind: "idle" }
+  /** Collect mined; waiting for a fresh claimable snapshot for both assets. */
+  | { kind: "await_claimables"; collectHash: string }
+  /** Ordered queue of assets still to claim (WETH always before token). */
+  | { kind: "claiming"; queue: ClaimAsset[]; active: ClaimAsset; collectHash?: string };
+
 /**
  * v2 fee card: the launch LP is locked forever in the {PotatoFeeLocker}. Its
  * Uniswap V3 swap fees flow out in two on-chain steps:
@@ -21,9 +35,8 @@ import { TxStatus } from "@/components/TxStatus";
  *      once per asset (WETH and the launched token).
  *
  * The UI folds both into ONE button. For the creator, "Collect & claim" fires
- * {collect} and then — once it confirms and the creator's balances land in the
- * locker — automatically fires {claim} for WETH and the token. Non-creators get
- * a plain "Collect fees" crank (anyone can collect; only the creator can claim).
+ * {collect} and then — once claimables refresh — automatically fires {claim}
+ * for WETH then the token. Non-creators get a plain "Collect fees" crank.
  */
 export function HarvestCard({
   creator,
@@ -80,17 +93,79 @@ export function HarvestCard({
 
   const claimableWeth = (creatorClaimableWeth as bigint | undefined) ?? 0n;
   const claimableToken = (creatorClaimableToken as bigint | undefined) ?? 0n;
+  const claimablesKnown =
+    creatorClaimableWeth !== undefined && creatorClaimableToken !== undefined;
   const hasClaimable = claimableWeth > 0n || claimableToken > 0n;
   const hasUncollected =
     (accrued.wethAmount ?? 0n) > 0n || (accrued.tokenAmount ?? 0n) > 0n;
 
-  const busy = collectTx.busy || claimWethTx.busy || claimTokenTx.busy;
-  // Nothing to do: no pool fees to harvest AND (for the creator) no standing
-  // balance to withdraw. Non-creators can only ever collect.
+  const [flow, setFlow] = useState<FeeFlow>({ kind: "idle" });
+  const flowRef = useRef(flow);
+  flowRef.current = flow;
+
+  // Drop in-flight orchestration when the user, chain, locker, or token changes
+  // so a latched receipt cannot claim against a different context.
+  useEffect(() => {
+    setFlow({ kind: "idle" });
+    collectTx.reset();
+    claimWethTx.reset();
+    claimTokenTx.reset();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only re-key on identity inputs
+  }, [user, chainId, lockerAddr, token, creator, lpTokenId]);
+
+  const busy =
+    collectTx.busy ||
+    claimWethTx.busy ||
+    claimTokenTx.busy ||
+    flow.kind === "await_claimables" ||
+    flow.kind === "claiming";
+
   const nothingToDo = !hasUncollected && !(isCreator && hasClaimable);
   const disabled = !lockerReady || busy || nothingToDo;
 
+  const writeClaim = useCallback(
+    (asset: ClaimAsset) => {
+      if (asset === "weth") {
+        claimWethTx.writeContract({
+          address: lockerAddr,
+          abi: potatoFeeLockerAbi,
+          functionName: "claim",
+          args: [weth],
+        });
+      } else {
+        claimTokenTx.writeContract({
+          address: lockerAddr,
+          abi: potatoFeeLockerAbi,
+          functionName: "claim",
+          args: [token],
+        });
+      }
+    },
+    // claim*Tx.writeContract identity is stable enough for our purposes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [lockerAddr, weth, token],
+  );
+
+  /** Build WETH-first claim queue from a known claimable snapshot. */
+  function buildQueue(wethAmt: bigint, tokenAmt: bigint): ClaimAsset[] {
+    const q: ClaimAsset[] = [];
+    if (wethAmt > 0n) q.push("weth");
+    if (tokenAmt > 0n) q.push("token");
+    return q;
+  }
+
+  function startQueue(queue: ClaimAsset[], collectHash?: string) {
+    if (queue.length === 0) {
+      setFlow({ kind: "idle" });
+      return;
+    }
+    const [active, ...rest] = queue;
+    setFlow({ kind: "claiming", queue: rest, active, collectHash });
+    writeClaim(active);
+  }
+
   function collect() {
+    setFlow({ kind: "idle" });
     collectTx.writeContract({
       address: lockerAddr,
       abi: potatoFeeLockerAbi,
@@ -99,94 +174,96 @@ export function HarvestCard({
     });
   }
 
-  function claimWeth() {
-    claimWethTx.writeContract({
-      address: lockerAddr,
-      abi: potatoFeeLockerAbi,
-      functionName: "claim",
-      args: [weth],
-    });
-  }
-
-  function claimToken() {
-    claimTokenTx.writeContract({
-      address: lockerAddr,
-      abi: potatoFeeLockerAbi,
-      functionName: "claim",
-      args: [token],
-    });
-  }
-
-  /** Kick off claims for any standing creator balances (WETH first, then token). */
+  /** Manual claim of standing balances (no collect). Snapshot now → queue. */
   function claimStanding() {
-    if (claimableWeth > 0n) {
-      claimWeth();
-      return;
-    }
-    if (claimableToken > 0n) {
-      claimToken();
-    }
+    if (!claimablesKnown) return;
+    startQueue(buildQueue(claimableWeth, claimableToken));
   }
 
   function handleClick() {
-    // Creator with a standing balance and nothing left in the pool → claim now.
     if (isCreator && !hasUncollected && hasClaimable) {
       claimStanding();
       return;
     }
-    // Otherwise harvest. For the creator this auto-chains into claims below.
     collect();
   }
 
-  // After a creator's collect confirms, the treasury is paid and the creator's
-  // share lands in the locker (react-query refetches `claimable`). Fire claims
-  // exactly once per collect, guarded by the collect tx hash.
-  const autoClaimedFor = useRef<string | undefined>(undefined);
+  // Collect confirmed → wait for a post-collect claimable snapshot (both assets
+  // known). Do not build the queue from pre-collect cached values.
   useEffect(() => {
+    if (!collectTx.confirmed || !collectTx.hash || !isCreator) return;
+    const f = flowRef.current;
+    // Already handling this collect (or a claim chain that started from it).
     if (
-      collectTx.confirmed &&
-      collectTx.hash &&
-      autoClaimedFor.current !== collectTx.hash &&
-      isCreator &&
-      hasClaimable &&
-      !claimWethTx.busy &&
-      !claimTokenTx.busy
+      (f.kind === "await_claimables" && f.collectHash === collectTx.hash) ||
+      (f.kind === "claiming" && f.collectHash === collectTx.hash)
     ) {
-      autoClaimedFor.current = collectTx.hash;
-      claimStanding();
+      return;
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [collectTx.confirmed, collectTx.hash, isCreator, claimableWeth, claimableToken]);
+    // Ignore if we're mid manual claim with no collect linkage.
+    if (f.kind === "claiming" && !f.collectHash) return;
+    setFlow({ kind: "await_claimables", collectHash: collectTx.hash });
+  }, [collectTx.confirmed, collectTx.hash, isCreator]);
 
-  // After WETH claim confirms, continue with token-side claim if still pending.
-  const tokenClaimedAfterWeth = useRef<string | undefined>(undefined);
+  // Once claimables are known after collect, freeze the ordered queue and start.
   useEffect(() => {
-    if (
-      claimWethTx.confirmed &&
-      claimWethTx.hash &&
-      tokenClaimedAfterWeth.current !== claimWethTx.hash &&
-      isCreator &&
-      claimableToken > 0n &&
-      !claimTokenTx.busy
-    ) {
-      tokenClaimedAfterWeth.current = claimWethTx.hash;
-      claimToken();
+    if (flow.kind !== "await_claimables") return;
+    if (!claimablesKnown) return;
+    // Still zero after a fresh read: nothing for creator to pull (e.g. only
+    // treasury share, or amounts already claimed). Stop cleanly.
+    startQueue(buildQueue(claimableWeth, claimableToken), flow.collectHash);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- deliberate snapshot when known
+  }, [flow, claimablesKnown, claimableWeth, claimableToken]);
+
+  // Advance the queue when the active claim confirms. Only one initiator owns
+  // token claims — never a separate effect on a latched WETH receipt.
+  useEffect(() => {
+    if (flow.kind !== "claiming") return;
+    const activeTx = flow.active === "weth" ? claimWethTx : claimTokenTx;
+    if (!activeTx.confirmed || !activeTx.hash) return;
+
+    const remaining = flow.queue;
+    if (remaining.length === 0) {
+      setFlow({ kind: "idle" });
+      return;
     }
+    const [next, ...rest] = remaining;
+    setFlow({
+      kind: "claiming",
+      queue: rest,
+      active: next,
+      collectHash: flow.collectHash,
+    });
+    writeClaim(next);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [claimWethTx.confirmed, claimWethTx.hash, isCreator, claimableToken]);
+  }, [
+    flow,
+    claimWethTx.confirmed,
+    claimWethTx.hash,
+    claimTokenTx.confirmed,
+    claimTokenTx.hash,
+  ]);
+
+  // If the active claim reverts or errors, abort the rest of the queue so we
+  // don't keep prompting the wallet against a broken state.
+  useEffect(() => {
+    if (flow.kind !== "claiming") return;
+    const activeTx = flow.active === "weth" ? claimWethTx : claimTokenTx;
+    if (activeTx.reverted || activeTx.error) {
+      setFlow({ kind: "idle" });
+    }
+  }, [flow, claimWethTx.reverted, claimWethTx.error, claimTokenTx.reverted, claimTokenTx.error]);
 
   let label: string;
   if (collectTx.busy) label = "Collecting…";
-  else if (claimWethTx.busy || claimTokenTx.busy) label = "Claiming…";
+  else if (flow.kind === "await_claimables") label = "Preparing claim…";
+  else if (claimWethTx.busy || claimTokenTx.busy || flow.kind === "claiming") label = "Claiming…";
   else if (nothingToDo) label = "No fees yet";
   else if (!isCreator) label = "Collect fees";
   else if (hasUncollected) label = "Collect & claim";
   else if (claimableWeth > 0n && claimableToken > 0n) label = "Claim fees";
   else if (claimableToken > 0n) label = `Claim ${symbol}`;
   else label = "Claim WETH";
-
-  const claimableKnown =
-    creatorClaimableWeth !== undefined && creatorClaimableToken !== undefined;
 
   return (
     <div className="card p-5">
@@ -214,7 +291,6 @@ export function HarvestCard({
         </p>
       </div>
 
-      {/* One unified fee action: collect (harvest into locker) then claim (withdraw). */}
       <div className="mt-4 rounded-lg border border-neutral-800 bg-neutral-950 p-3">
         <div className="flex items-center justify-between gap-3">
           <div>
@@ -239,7 +315,7 @@ export function HarvestCard({
         <div className="mt-3 flex items-baseline justify-between gap-3 border-t border-neutral-800 pt-3">
           <p className="text-xs text-neutral-500">Ready to claim (creator)</p>
           <p className="font-mono text-sm font-semibold text-neutral-100">
-            {claimableKnown
+            {claimablesKnown
               ? `${formatEth(claimableWeth)} WETH + ${formatTokens(claimableToken)} ${symbol}`
               : "…"}
           </p>

--- a/web/components/HarvestCard.tsx
+++ b/web/components/HarvestCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Coins, Leaf, Lock } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Address } from "viem";
 import { useAccount, useReadContract } from "wagmi";
 import { potatoFeeLockerAbi, potatoPadAbi } from "@/lib/abi";
@@ -14,24 +14,43 @@ import { TxStatus } from "@/components/TxStatus";
 
 type ClaimAsset = "weth" | "token";
 
-/**
- * Orchestration for collect → ordered claims. One machine owns the whole flow so
- * latched receipt flags from a prior claim cannot re-fire claims later, and
- * independent claimable refetches cannot start the wrong asset first.
- */
+/** Immutable binding for a collect→claim orchestration — rejects stale continuations. */
+type FlowCtx = {
+  user: string;
+  chainId: number;
+  locker: string;
+  token: string;
+  creator: string;
+  lpTokenId: string;
+};
+
 type FeeFlow =
   | { kind: "idle" }
-  /** Collect mined; waiting for a fresh (post-collect) claimable snapshot. */
-  | { kind: "await_claimables"; collectHash: string; minUpdatedAt: number }
-  /** Ordered queue of assets still to claim (WETH always before token). */
+  | {
+      kind: "await_claimables";
+      collectHash: string;
+      minUpdatedAt: number;
+      ctx: FlowCtx;
+    }
   | {
       kind: "claiming";
       queue: ClaimAsset[];
       active: ClaimAsset;
       collectHash?: string;
-      /** Receipt hashes already consumed to advance the queue (dedupe). */
       advanced: ReadonlySet<string>;
+      ctx: FlowCtx;
     };
+
+function sameCtx(a: FlowCtx, b: FlowCtx): boolean {
+  return (
+    a.user === b.user &&
+    a.chainId === b.chainId &&
+    a.locker === b.locker &&
+    a.token === b.token &&
+    a.creator === b.creator &&
+    a.lpTokenId === b.lpTokenId
+  );
+}
 
 /**
  * v2 fee card: the launch LP is locked forever in the {PotatoFeeLocker}. Its
@@ -114,11 +133,28 @@ export function HarvestCard({
   const hasUncollected =
     (accrued.wethAmount ?? 0n) > 0n || (accrued.tokenAmount ?? 0n) > 0n;
 
+  // Live claimable snapshot for timeout callbacks (avoid stale closures).
+  const claimableRef = useRef({ weth: claimableWeth, token: claimableToken, known: claimablesKnown });
+  claimableRef.current = { weth: claimableWeth, token: claimableToken, known: claimablesKnown };
+
+  const ctx: FlowCtx = useMemo(
+    () => ({
+      user: (user ?? "").toLowerCase(),
+      chainId,
+      locker: lockerAddr.toLowerCase(),
+      token: token.toLowerCase(),
+      creator: creator.toLowerCase(),
+      lpTokenId: lpTokenId.toString(),
+    }),
+    [user, chainId, lockerAddr, token, creator, lpTokenId],
+  );
+  const ctxRef = useRef(ctx);
+  ctxRef.current = ctx;
+
   const [flow, setFlow] = useState<FeeFlow>({ kind: "idle" });
   const flowRef = useRef(flow);
   flowRef.current = flow;
 
-  // Stable refs to tx helpers so identity-reset effect doesn't need them as deps.
   const collectTxRef = useRef(collectTx);
   const claimWethTxRef = useRef(claimWethTx);
   const claimTokenTxRef = useRef(claimTokenTx);
@@ -126,14 +162,15 @@ export function HarvestCard({
   claimWethTxRef.current = claimWethTx;
   claimTokenTxRef.current = claimTokenTx;
 
-  // Drop in-flight orchestration when the user, chain, locker, or token changes
-  // so a latched receipt cannot claim against a different context.
+  // Bump epoch on context change; all in-flight continuations check this.
+  const epochRef = useRef(0);
   useEffect(() => {
+    epochRef.current += 1;
     setFlow({ kind: "idle" });
     collectTxRef.current.reset();
     claimWethTxRef.current.reset();
     claimTokenTxRef.current.reset();
-  }, [user, chainId, lockerAddr, token, creator, lpTokenId]);
+  }, [ctx.user, ctx.chainId, ctx.locker, ctx.token, ctx.creator, ctx.lpTokenId]);
 
   const busy =
     collectTx.busy ||
@@ -145,25 +182,30 @@ export function HarvestCard({
   const nothingToDo = !hasUncollected && !(isCreator && hasClaimable);
   const disabled = !lockerReady || busy || nothingToDo;
 
-  const writeClaim = useCallback((asset: ClaimAsset) => {
-    if (asset === "weth") {
-      claimWethTxRef.current.writeContract({
-        address: lockerAddr,
-        abi: potatoFeeLockerAbi,
-        functionName: "claim",
-        args: [weth],
-      });
-    } else {
-      claimTokenTxRef.current.writeContract({
-        address: lockerAddr,
-        abi: potatoFeeLockerAbi,
-        functionName: "claim",
-        args: [token],
-      });
-    }
-  }, [lockerAddr, weth, token]);
+  const writeClaim = useCallback(
+    (asset: ClaimAsset, expectedCtx: FlowCtx, epoch: number) => {
+      // Refuse to submit if the account/chain/token context drifted.
+      if (epoch !== epochRef.current) return;
+      if (!sameCtx(expectedCtx, ctxRef.current)) return;
+      if (asset === "weth") {
+        claimWethTxRef.current.writeContract({
+          address: lockerAddr,
+          abi: potatoFeeLockerAbi,
+          functionName: "claim",
+          args: [weth],
+        });
+      } else {
+        claimTokenTxRef.current.writeContract({
+          address: lockerAddr,
+          abi: potatoFeeLockerAbi,
+          functionName: "claim",
+          args: [token],
+        });
+      }
+    },
+    [lockerAddr, weth, token],
+  );
 
-  /** Build WETH-first claim queue from a known claimable snapshot. */
   function buildQueue(wethAmt: bigint, tokenAmt: bigint): ClaimAsset[] {
     const q: ClaimAsset[] = [];
     if (wethAmt > 0n) q.push("weth");
@@ -171,9 +213,10 @@ export function HarvestCard({
     return q;
   }
 
-  function startQueue(queue: ClaimAsset[], collectHash?: string) {
-    // Clear latched receipts so a prior confirmed claim can't immediately
-    // advance / re-fire the new queue.
+  function startQueue(queue: ClaimAsset[], collectHash: string | undefined, expectedCtx: FlowCtx) {
+    const epoch = epochRef.current;
+    if (!sameCtx(expectedCtx, ctxRef.current)) return;
+
     claimWethTxRef.current.reset();
     claimTokenTxRef.current.reset();
 
@@ -188,8 +231,9 @@ export function HarvestCard({
       active,
       collectHash,
       advanced: new Set(),
+      ctx: expectedCtx,
     });
-    writeClaim(active);
+    writeClaim(active, expectedCtx, epoch);
   }
 
   function collect() {
@@ -202,10 +246,9 @@ export function HarvestCard({
     });
   }
 
-  /** Manual claim of standing balances (no collect). Snapshot now → queue. */
   function claimStanding() {
     if (!claimablesKnown) return;
-    startQueue(buildQueue(claimableWeth, claimableToken));
+    startQueue(buildQueue(claimableWeth, claimableToken), undefined, ctx);
   }
 
   function handleClick() {
@@ -216,8 +259,8 @@ export function HarvestCard({
     collect();
   }
 
-  // Collect confirmed → wait for a post-collect claimable snapshot (both assets
-  // refreshed after invalidateQueries). Do not build the queue from pre-collect cache.
+  // Collect confirmed → wait for a fresh post-collect claimable snapshot.
+  // Only the creator who owns the current context may auto-claim.
   useEffect(() => {
     if (!collectTx.confirmed || !collectTx.hash || !isCreator) return;
     const f = flowRef.current;
@@ -227,30 +270,31 @@ export function HarvestCard({
     ) {
       return;
     }
-    // Ignore if mid manual claim with no collect linkage.
     if (f.kind === "claiming" && !f.collectHash) return;
+
+    // Snapshot the context at collect-handling time; later transitions must match.
+    const bound = ctxRef.current;
     setFlow({
       kind: "await_claimables",
       collectHash: collectTx.hash,
-      // Require claimable queries to have updated at/after this moment.
       minUpdatedAt: Date.now(),
+      ctx: bound,
     });
   }, [collectTx.confirmed, collectTx.hash, isCreator]);
 
-  // Once both claimables are known AND freshly updated after collect, freeze the
-  // ordered queue and start. Waiting on dataUpdatedAt + !isFetching closes the
-  // race where a standing token balance would claim before newly collected WETH
-  // appears in cache.
+  // Fresh claimables ready → freeze WETH-then-token queue.
   useEffect(() => {
     if (flow.kind !== "await_claimables") return;
+    if (!sameCtx(flow.ctx, ctx)) return; // context drifted — identity effect will idle
     if (!claimablesKnown) return;
     if (wethFetching || tokenFetching) return;
     if (wethUpdatedAt < flow.minUpdatedAt || tokenUpdatedAt < flow.minUpdatedAt) return;
 
-    startQueue(buildQueue(claimableWeth, claimableToken), flow.collectHash);
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- deliberate snapshot when fresh
+    startQueue(buildQueue(claimableWeth, claimableToken), flow.collectHash, flow.ctx);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     flow,
+    ctx,
     claimablesKnown,
     claimableWeth,
     claimableToken,
@@ -260,28 +304,32 @@ export function HarvestCard({
     tokenUpdatedAt,
   ]);
 
-  // Fallback: if claimable queries never refresh (RPC stall), don't leave the
-  // creator stuck on "Preparing claim…". Proceed with best-known balances.
+  // Fallback: read latest claimables from refs so a partial refresh still
+  // includes newly collected WETH even if one query stalled.
   useEffect(() => {
     if (flow.kind !== "await_claimables") return;
     const collectHash = flow.collectHash;
+    const bound = flow.ctx;
     const t = setTimeout(() => {
       if (flowRef.current.kind !== "await_claimables") return;
       if (flowRef.current.collectHash !== collectHash) return;
-      startQueue(buildQueue(claimableWeth, claimableToken), collectHash);
+      if (!sameCtx(bound, ctxRef.current)) return;
+      const snap = claimableRef.current;
+      startQueue(buildQueue(snap.weth, snap.token), collectHash, bound);
     }, 8_000);
     return () => clearTimeout(t);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [flow.kind === "await_claimables" ? flow.collectHash : null]);
 
-  // Advance the queue when the active claim confirms. Each receipt hash advances
-  // the machine at most once — never a separate effect on a latched WETH receipt.
+  // Advance queue on active claim confirmation (each receipt once).
   useEffect(() => {
     if (flow.kind !== "claiming") return;
+    if (!sameCtx(flow.ctx, ctx)) return;
     const activeTx = flow.active === "weth" ? claimWethTx : claimTokenTx;
     if (!activeTx.confirmed || !activeTx.hash) return;
     if (flow.advanced.has(activeTx.hash)) return;
 
+    const epoch = epochRef.current;
     const advanced = new Set(flow.advanced);
     advanced.add(activeTx.hash);
 
@@ -297,10 +345,12 @@ export function HarvestCard({
       active: next,
       collectHash: flow.collectHash,
       advanced,
+      ctx: flow.ctx,
     });
-    writeClaim(next);
+    writeClaim(next, flow.ctx, epoch);
   }, [
     flow,
+    ctx,
     claimWethTx.confirmed,
     claimWethTx.hash,
     claimTokenTx.confirmed,
@@ -308,8 +358,6 @@ export function HarvestCard({
     writeClaim,
   ]);
 
-  // If the active claim reverts or errors, abort the rest of the queue so we
-  // don't keep prompting the wallet against a broken state.
   useEffect(() => {
     if (flow.kind !== "claiming") return;
     const activeTx = flow.active === "weth" ? claimWethTx : claimTokenTx;

--- a/web/components/HarvestCard.tsx
+++ b/web/components/HarvestCard.tsx
@@ -21,10 +21,17 @@ type ClaimAsset = "weth" | "token";
  */
 type FeeFlow =
   | { kind: "idle" }
-  /** Collect mined; waiting for a fresh claimable snapshot for both assets. */
-  | { kind: "await_claimables"; collectHash: string }
+  /** Collect mined; waiting for a fresh (post-collect) claimable snapshot. */
+  | { kind: "await_claimables"; collectHash: string; minUpdatedAt: number }
   /** Ordered queue of assets still to claim (WETH always before token). */
-  | { kind: "claiming"; queue: ClaimAsset[]; active: ClaimAsset; collectHash?: string };
+  | {
+      kind: "claiming";
+      queue: ClaimAsset[];
+      active: ClaimAsset;
+      collectHash?: string;
+      /** Receipt hashes already consumed to advance the queue (dedupe). */
+      advanced: ReadonlySet<string>;
+    };
 
 /**
  * v2 fee card: the launch LP is locked forever in the {PotatoFeeLocker}. Its
@@ -73,7 +80,11 @@ export function HarvestCard({
   const lockerReady = lockerAddr !== ZERO_ADDRESS;
   const tokenReady = token !== ZERO_ADDRESS;
 
-  const { data: creatorClaimableWeth } = useReadContract({
+  const {
+    data: creatorClaimableWeth,
+    dataUpdatedAt: wethUpdatedAt,
+    isFetching: wethFetching,
+  } = useReadContract({
     address: lockerAddr,
     abi: potatoFeeLockerAbi,
     functionName: "claimable",
@@ -81,7 +92,11 @@ export function HarvestCard({
     query: { enabled: lockerReady && weth !== ZERO_ADDRESS },
   });
 
-  const { data: creatorClaimableToken } = useReadContract({
+  const {
+    data: creatorClaimableToken,
+    dataUpdatedAt: tokenUpdatedAt,
+    isFetching: tokenFetching,
+  } = useReadContract({
     address: lockerAddr,
     abi: potatoFeeLockerAbi,
     functionName: "claimable",
@@ -103,14 +118,21 @@ export function HarvestCard({
   const flowRef = useRef(flow);
   flowRef.current = flow;
 
+  // Stable refs to tx helpers so identity-reset effect doesn't need them as deps.
+  const collectTxRef = useRef(collectTx);
+  const claimWethTxRef = useRef(claimWethTx);
+  const claimTokenTxRef = useRef(claimTokenTx);
+  collectTxRef.current = collectTx;
+  claimWethTxRef.current = claimWethTx;
+  claimTokenTxRef.current = claimTokenTx;
+
   // Drop in-flight orchestration when the user, chain, locker, or token changes
   // so a latched receipt cannot claim against a different context.
   useEffect(() => {
     setFlow({ kind: "idle" });
-    collectTx.reset();
-    claimWethTx.reset();
-    claimTokenTx.reset();
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- only re-key on identity inputs
+    collectTxRef.current.reset();
+    claimWethTxRef.current.reset();
+    claimTokenTxRef.current.reset();
   }, [user, chainId, lockerAddr, token, creator, lpTokenId]);
 
   const busy =
@@ -123,28 +145,23 @@ export function HarvestCard({
   const nothingToDo = !hasUncollected && !(isCreator && hasClaimable);
   const disabled = !lockerReady || busy || nothingToDo;
 
-  const writeClaim = useCallback(
-    (asset: ClaimAsset) => {
-      if (asset === "weth") {
-        claimWethTx.writeContract({
-          address: lockerAddr,
-          abi: potatoFeeLockerAbi,
-          functionName: "claim",
-          args: [weth],
-        });
-      } else {
-        claimTokenTx.writeContract({
-          address: lockerAddr,
-          abi: potatoFeeLockerAbi,
-          functionName: "claim",
-          args: [token],
-        });
-      }
-    },
-    // claim*Tx.writeContract identity is stable enough for our purposes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [lockerAddr, weth, token],
-  );
+  const writeClaim = useCallback((asset: ClaimAsset) => {
+    if (asset === "weth") {
+      claimWethTxRef.current.writeContract({
+        address: lockerAddr,
+        abi: potatoFeeLockerAbi,
+        functionName: "claim",
+        args: [weth],
+      });
+    } else {
+      claimTokenTxRef.current.writeContract({
+        address: lockerAddr,
+        abi: potatoFeeLockerAbi,
+        functionName: "claim",
+        args: [token],
+      });
+    }
+  }, [lockerAddr, weth, token]);
 
   /** Build WETH-first claim queue from a known claimable snapshot. */
   function buildQueue(wethAmt: bigint, tokenAmt: bigint): ClaimAsset[] {
@@ -155,12 +172,23 @@ export function HarvestCard({
   }
 
   function startQueue(queue: ClaimAsset[], collectHash?: string) {
+    // Clear latched receipts so a prior confirmed claim can't immediately
+    // advance / re-fire the new queue.
+    claimWethTxRef.current.reset();
+    claimTokenTxRef.current.reset();
+
     if (queue.length === 0) {
       setFlow({ kind: "idle" });
       return;
     }
     const [active, ...rest] = queue;
-    setFlow({ kind: "claiming", queue: rest, active, collectHash });
+    setFlow({
+      kind: "claiming",
+      queue: rest,
+      active,
+      collectHash,
+      advanced: new Set(),
+    });
     writeClaim(active);
   }
 
@@ -189,38 +217,73 @@ export function HarvestCard({
   }
 
   // Collect confirmed → wait for a post-collect claimable snapshot (both assets
-  // known). Do not build the queue from pre-collect cached values.
+  // refreshed after invalidateQueries). Do not build the queue from pre-collect cache.
   useEffect(() => {
     if (!collectTx.confirmed || !collectTx.hash || !isCreator) return;
     const f = flowRef.current;
-    // Already handling this collect (or a claim chain that started from it).
     if (
       (f.kind === "await_claimables" && f.collectHash === collectTx.hash) ||
       (f.kind === "claiming" && f.collectHash === collectTx.hash)
     ) {
       return;
     }
-    // Ignore if we're mid manual claim with no collect linkage.
+    // Ignore if mid manual claim with no collect linkage.
     if (f.kind === "claiming" && !f.collectHash) return;
-    setFlow({ kind: "await_claimables", collectHash: collectTx.hash });
+    setFlow({
+      kind: "await_claimables",
+      collectHash: collectTx.hash,
+      // Require claimable queries to have updated at/after this moment.
+      minUpdatedAt: Date.now(),
+    });
   }, [collectTx.confirmed, collectTx.hash, isCreator]);
 
-  // Once claimables are known after collect, freeze the ordered queue and start.
+  // Once both claimables are known AND freshly updated after collect, freeze the
+  // ordered queue and start. Waiting on dataUpdatedAt + !isFetching closes the
+  // race where a standing token balance would claim before newly collected WETH
+  // appears in cache.
   useEffect(() => {
     if (flow.kind !== "await_claimables") return;
     if (!claimablesKnown) return;
-    // Still zero after a fresh read: nothing for creator to pull (e.g. only
-    // treasury share, or amounts already claimed). Stop cleanly.
-    startQueue(buildQueue(claimableWeth, claimableToken), flow.collectHash);
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- deliberate snapshot when known
-  }, [flow, claimablesKnown, claimableWeth, claimableToken]);
+    if (wethFetching || tokenFetching) return;
+    if (wethUpdatedAt < flow.minUpdatedAt || tokenUpdatedAt < flow.minUpdatedAt) return;
 
-  // Advance the queue when the active claim confirms. Only one initiator owns
-  // token claims — never a separate effect on a latched WETH receipt.
+    startQueue(buildQueue(claimableWeth, claimableToken), flow.collectHash);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- deliberate snapshot when fresh
+  }, [
+    flow,
+    claimablesKnown,
+    claimableWeth,
+    claimableToken,
+    wethFetching,
+    tokenFetching,
+    wethUpdatedAt,
+    tokenUpdatedAt,
+  ]);
+
+  // Fallback: if claimable queries never refresh (RPC stall), don't leave the
+  // creator stuck on "Preparing claim…". Proceed with best-known balances.
+  useEffect(() => {
+    if (flow.kind !== "await_claimables") return;
+    const collectHash = flow.collectHash;
+    const t = setTimeout(() => {
+      if (flowRef.current.kind !== "await_claimables") return;
+      if (flowRef.current.collectHash !== collectHash) return;
+      startQueue(buildQueue(claimableWeth, claimableToken), collectHash);
+    }, 8_000);
+    return () => clearTimeout(t);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [flow.kind === "await_claimables" ? flow.collectHash : null]);
+
+  // Advance the queue when the active claim confirms. Each receipt hash advances
+  // the machine at most once — never a separate effect on a latched WETH receipt.
   useEffect(() => {
     if (flow.kind !== "claiming") return;
     const activeTx = flow.active === "weth" ? claimWethTx : claimTokenTx;
     if (!activeTx.confirmed || !activeTx.hash) return;
+    if (flow.advanced.has(activeTx.hash)) return;
+
+    const advanced = new Set(flow.advanced);
+    advanced.add(activeTx.hash);
 
     const remaining = flow.queue;
     if (remaining.length === 0) {
@@ -233,15 +296,16 @@ export function HarvestCard({
       queue: rest,
       active: next,
       collectHash: flow.collectHash,
+      advanced,
     });
     writeClaim(next);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     flow,
     claimWethTx.confirmed,
     claimWethTx.hash,
     claimTokenTx.confirmed,
     claimTokenTx.hash,
+    writeClaim,
   ]);
 
   // If the active claim reverts or errors, abort the rest of the queue so we

--- a/web/components/HarvestCard.tsx
+++ b/web/components/HarvestCard.tsx
@@ -17,23 +17,27 @@ import { TxStatus } from "@/components/TxStatus";
  * Uniswap V3 swap fees flow out in two on-chain steps:
  *   1. {collect} (permissionless) harvests accrued pool fees INTO the locker,
  *      auto-pays the treasury its 50%, and sets aside the creator's 50%.
- *   2. {claim} (creator-only) withdraws that set-aside share to the wallet.
+ *   2. {claim} (creator-only) withdraws that set-aside share to the wallet —
+ *      once per asset (WETH and the launched token).
  *
  * The UI folds both into ONE button. For the creator, "Collect & claim" fires
- * {collect} and then — once it confirms and the creator's balance lands in the
- * locker — automatically fires {claim} for them. Non-creators get a plain
- * "Collect fees" crank (anyone can collect; only the creator can claim).
+ * {collect} and then — once it confirms and the creator's balances land in the
+ * locker — automatically fires {claim} for WETH and the token. Non-creators get
+ * a plain "Collect fees" crank (anyone can collect; only the creator can claim).
  */
 export function HarvestCard({
   creator,
   lpTokenId,
   pool,
+  token,
   symbol,
   pad,
 }: {
   creator: Address;
   lpTokenId: bigint;
   pool: Address;
+  /** Launched token address — fees also accrue on this side of the pool. */
+  token: Address;
   symbol: string;
   /** The pad that launched this token (primary or legacy) — its locker holds the fees. */
   pad: Address;
@@ -41,7 +45,8 @@ export function HarvestCard({
   const { address: user, isConnected } = useAccount();
   const { weth, chainId } = usePad();
   const collectTx = useTx();
-  const claimTx = useTx();
+  const claimWethTx = useTx();
+  const claimTokenTx = useTx();
   const accrued = useAccruedFees(lpTokenId, pool, pad);
 
   const { data: locker } = useReadContract({
@@ -53,8 +58,9 @@ export function HarvestCard({
 
   const lockerAddr = (locker as Address | undefined) ?? ZERO_ADDRESS;
   const lockerReady = lockerAddr !== ZERO_ADDRESS;
+  const tokenReady = token !== ZERO_ADDRESS;
 
-  const { data: creatorClaimable } = useReadContract({
+  const { data: creatorClaimableWeth } = useReadContract({
     address: lockerAddr,
     abi: potatoFeeLockerAbi,
     functionName: "claimable",
@@ -62,14 +68,23 @@ export function HarvestCard({
     query: { enabled: lockerReady && weth !== ZERO_ADDRESS },
   });
 
+  const { data: creatorClaimableToken } = useReadContract({
+    address: lockerAddr,
+    abi: potatoFeeLockerAbi,
+    functionName: "claimable",
+    args: [token, creator],
+    query: { enabled: lockerReady && tokenReady },
+  });
+
   const isCreator = !!user && user.toLowerCase() === creator.toLowerCase();
 
-  const claimableAmt = (creatorClaimable as bigint | undefined) ?? 0n;
-  const hasClaimable = claimableAmt > 0n;
+  const claimableWeth = (creatorClaimableWeth as bigint | undefined) ?? 0n;
+  const claimableToken = (creatorClaimableToken as bigint | undefined) ?? 0n;
+  const hasClaimable = claimableWeth > 0n || claimableToken > 0n;
   const hasUncollected =
     (accrued.wethAmount ?? 0n) > 0n || (accrued.tokenAmount ?? 0n) > 0n;
 
-  const busy = collectTx.busy || claimTx.busy;
+  const busy = collectTx.busy || claimWethTx.busy || claimTokenTx.busy;
   // Nothing to do: no pool fees to harvest AND (for the creator) no standing
   // balance to withdraw. Non-creators can only ever collect.
   const nothingToDo = !hasUncollected && !(isCreator && hasClaimable);
@@ -84,8 +99,8 @@ export function HarvestCard({
     });
   }
 
-  function claim() {
-    claimTx.writeContract({
+  function claimWeth() {
+    claimWethTx.writeContract({
       address: lockerAddr,
       abi: potatoFeeLockerAbi,
       functionName: "claim",
@@ -93,19 +108,39 @@ export function HarvestCard({
     });
   }
 
+  function claimToken() {
+    claimTokenTx.writeContract({
+      address: lockerAddr,
+      abi: potatoFeeLockerAbi,
+      functionName: "claim",
+      args: [token],
+    });
+  }
+
+  /** Kick off claims for any standing creator balances (WETH first, then token). */
+  function claimStanding() {
+    if (claimableWeth > 0n) {
+      claimWeth();
+      return;
+    }
+    if (claimableToken > 0n) {
+      claimToken();
+    }
+  }
+
   function handleClick() {
     // Creator with a standing balance and nothing left in the pool → claim now.
     if (isCreator && !hasUncollected && hasClaimable) {
-      claim();
+      claimStanding();
       return;
     }
-    // Otherwise harvest. For the creator this auto-chains into a claim below.
+    // Otherwise harvest. For the creator this auto-chains into claims below.
     collect();
   }
 
   // After a creator's collect confirms, the treasury is paid and the creator's
-  // share lands in the locker (react-query refetches `claimable`). Fire the
-  // claim exactly once per collect, guarded by the collect tx hash.
+  // share lands in the locker (react-query refetches `claimable`). Fire claims
+  // exactly once per collect, guarded by the collect tx hash.
   const autoClaimedFor = useRef<string | undefined>(undefined);
   useEffect(() => {
     if (
@@ -113,22 +148,45 @@ export function HarvestCard({
       collectTx.hash &&
       autoClaimedFor.current !== collectTx.hash &&
       isCreator &&
-      claimableAmt > 0n &&
-      !claimTx.busy
+      hasClaimable &&
+      !claimWethTx.busy &&
+      !claimTokenTx.busy
     ) {
       autoClaimedFor.current = collectTx.hash;
-      claim();
+      claimStanding();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [collectTx.confirmed, collectTx.hash, isCreator, claimableAmt]);
+  }, [collectTx.confirmed, collectTx.hash, isCreator, claimableWeth, claimableToken]);
+
+  // After WETH claim confirms, continue with token-side claim if still pending.
+  const tokenClaimedAfterWeth = useRef<string | undefined>(undefined);
+  useEffect(() => {
+    if (
+      claimWethTx.confirmed &&
+      claimWethTx.hash &&
+      tokenClaimedAfterWeth.current !== claimWethTx.hash &&
+      isCreator &&
+      claimableToken > 0n &&
+      !claimTokenTx.busy
+    ) {
+      tokenClaimedAfterWeth.current = claimWethTx.hash;
+      claimToken();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [claimWethTx.confirmed, claimWethTx.hash, isCreator, claimableToken]);
 
   let label: string;
   if (collectTx.busy) label = "Collecting…";
-  else if (claimTx.busy) label = "Claiming…";
+  else if (claimWethTx.busy || claimTokenTx.busy) label = "Claiming…";
   else if (nothingToDo) label = "No fees yet";
   else if (!isCreator) label = "Collect fees";
   else if (hasUncollected) label = "Collect & claim";
+  else if (claimableWeth > 0n && claimableToken > 0n) label = "Claim fees";
+  else if (claimableToken > 0n) label = `Claim ${symbol}`;
   else label = "Claim WETH";
+
+  const claimableKnown =
+    creatorClaimableWeth !== undefined && creatorClaimableToken !== undefined;
 
   return (
     <div className="card p-5">
@@ -181,16 +239,17 @@ export function HarvestCard({
         <div className="mt-3 flex items-baseline justify-between gap-3 border-t border-neutral-800 pt-3">
           <p className="text-xs text-neutral-500">Ready to claim (creator)</p>
           <p className="font-mono text-sm font-semibold text-neutral-100">
-            {creatorClaimable !== undefined
-              ? `${formatEth(claimableAmt)} WETH`
+            {claimableKnown
+              ? `${formatEth(claimableWeth)} WETH + ${formatTokens(claimableToken)} ${symbol}`
               : "…"}
           </p>
         </div>
 
         <p className="mt-2 text-[11px] text-neutral-600">
-          Fees accrue in the Uniswap position as people trade. Collecting harvests them into
-          the locker — the treasury is auto-paid its 50% and the creator&apos;s 50% is set
-          aside — then the creator claims their share. One click does both.
+          Fees accrue in the Uniswap position as people trade (WETH and {symbol}). Collecting
+          harvests them into the locker — the treasury is auto-paid its 50% and the
+          creator&apos;s 50% is set aside — then the creator claims both sides. One click does
+          both.
         </p>
         {isConnected && !isCreator && (
           <p className="mt-1 text-[11px] text-neutral-600">
@@ -204,7 +263,16 @@ export function HarvestCard({
           chainId={chainId}
           successLabel="Collected fees into the locker."
         />
-        <TxStatus tx={claimTx} chainId={chainId} successLabel="Claimed your WETH fees!" />
+        <TxStatus
+          tx={claimWethTx}
+          chainId={chainId}
+          successLabel="Claimed your WETH fees!"
+        />
+        <TxStatus
+          tx={claimTokenTx}
+          chainId={chainId}
+          successLabel={`Claimed your ${symbol} fees!`}
+        />
       </div>
     </div>
   );

--- a/web/components/HarvestCard.tsx
+++ b/web/components/HarvestCard.tsx
@@ -26,12 +26,11 @@ type FlowCtx = {
 
 type FeeFlow =
   | { kind: "idle" }
-  | {
-      kind: "await_claimables";
-      collectHash: string;
-      minUpdatedAt: number;
-      ctx: FlowCtx;
-    }
+  /** Collect submitted; context frozen at click time. */
+  | { kind: "collecting"; ctx: FlowCtx; epoch: number }
+  /** Collect mined; explicit refetch of both claimables in flight. */
+  | { kind: "await_claimables"; collectHash: string; ctx: FlowCtx; epoch: number }
+  /** Ordered WETH-then-token claims in progress. */
   | {
       kind: "claiming";
       queue: ClaimAsset[];
@@ -39,6 +38,7 @@ type FeeFlow =
       collectHash?: string;
       advanced: ReadonlySet<string>;
       ctx: FlowCtx;
+      epoch: number;
     };
 
 function sameCtx(a: FlowCtx, b: FlowCtx): boolean {
@@ -61,8 +61,8 @@ function sameCtx(a: FlowCtx, b: FlowCtx): boolean {
  *      once per asset (WETH and the launched token).
  *
  * The UI folds both into ONE button. For the creator, "Collect & claim" fires
- * {collect} and then — once claimables refresh — automatically fires {claim}
- * for WETH then the token. Non-creators get a plain "Collect fees" crank.
+ * {collect} and then — once claimables are explicitly refetched — automatically
+ * fires {claim} for WETH then the token. Non-creators get a plain "Collect fees".
  */
 export function HarvestCard({
   creator,
@@ -75,10 +75,8 @@ export function HarvestCard({
   creator: Address;
   lpTokenId: bigint;
   pool: Address;
-  /** Launched token address — fees also accrue on this side of the pool. */
   token: Address;
   symbol: string;
-  /** The pad that launched this token (primary or legacy) — its locker holds the fees. */
   pad: Address;
 }) {
   const { address: user, isConnected } = useAccount();
@@ -101,8 +99,7 @@ export function HarvestCard({
 
   const {
     data: creatorClaimableWeth,
-    dataUpdatedAt: wethUpdatedAt,
-    isFetching: wethFetching,
+    refetch: refetchWethClaimable,
   } = useReadContract({
     address: lockerAddr,
     abi: potatoFeeLockerAbi,
@@ -113,8 +110,7 @@ export function HarvestCard({
 
   const {
     data: creatorClaimableToken,
-    dataUpdatedAt: tokenUpdatedAt,
-    isFetching: tokenFetching,
+    refetch: refetchTokenClaimable,
   } = useReadContract({
     address: lockerAddr,
     abi: potatoFeeLockerAbi,
@@ -132,10 +128,6 @@ export function HarvestCard({
   const hasClaimable = claimableWeth > 0n || claimableToken > 0n;
   const hasUncollected =
     (accrued.wethAmount ?? 0n) > 0n || (accrued.tokenAmount ?? 0n) > 0n;
-
-  // Live claimable snapshot for timeout callbacks (avoid stale closures).
-  const claimableRef = useRef({ weth: claimableWeth, token: claimableToken, known: claimablesKnown });
-  claimableRef.current = { weth: claimableWeth, token: claimableToken, known: claimablesKnown };
 
   const ctx: FlowCtx = useMemo(
     () => ({
@@ -162,7 +154,11 @@ export function HarvestCard({
   claimWethTxRef.current = claimWethTx;
   claimTokenTxRef.current = claimTokenTx;
 
-  // Bump epoch on context change; all in-flight continuations check this.
+  const refetchWethRef = useRef(refetchWethClaimable);
+  const refetchTokenRef = useRef(refetchTokenClaimable);
+  refetchWethRef.current = refetchWethClaimable;
+  refetchTokenRef.current = refetchTokenClaimable;
+
   const epochRef = useRef(0);
   useEffect(() => {
     epochRef.current += 1;
@@ -176,17 +172,20 @@ export function HarvestCard({
     collectTx.busy ||
     claimWethTx.busy ||
     claimTokenTx.busy ||
+    flow.kind === "collecting" ||
     flow.kind === "await_claimables" ||
     flow.kind === "claiming";
 
   const nothingToDo = !hasUncollected && !(isCreator && hasClaimable);
   const disabled = !lockerReady || busy || nothingToDo;
 
+  const flowStillValid = useCallback((bound: FlowCtx, epoch: number) => {
+    return epoch === epochRef.current && sameCtx(bound, ctxRef.current);
+  }, []);
+
   const writeClaim = useCallback(
     (asset: ClaimAsset, expectedCtx: FlowCtx, epoch: number) => {
-      // Refuse to submit if the account/chain/token context drifted.
-      if (epoch !== epochRef.current) return;
-      if (!sameCtx(expectedCtx, ctxRef.current)) return;
+      if (!flowStillValid(expectedCtx, epoch)) return;
       if (asset === "weth") {
         claimWethTxRef.current.writeContract({
           address: lockerAddr,
@@ -203,7 +202,7 @@ export function HarvestCard({
         });
       }
     },
-    [lockerAddr, weth, token],
+    [lockerAddr, weth, token, flowStillValid],
   );
 
   function buildQueue(wethAmt: bigint, tokenAmt: bigint): ClaimAsset[] {
@@ -213,9 +212,13 @@ export function HarvestCard({
     return q;
   }
 
-  function startQueue(queue: ClaimAsset[], collectHash: string | undefined, expectedCtx: FlowCtx) {
-    const epoch = epochRef.current;
-    if (!sameCtx(expectedCtx, ctxRef.current)) return;
+  function startQueue(
+    queue: ClaimAsset[],
+    collectHash: string | undefined,
+    expectedCtx: FlowCtx,
+    epoch: number,
+  ) {
+    if (!flowStillValid(expectedCtx, epoch)) return;
 
     claimWethTxRef.current.reset();
     claimTokenTxRef.current.reset();
@@ -232,12 +235,17 @@ export function HarvestCard({
       collectHash,
       advanced: new Set(),
       ctx: expectedCtx,
+      epoch,
     });
     writeClaim(active, expectedCtx, epoch);
   }
 
   function collect() {
-    setFlow({ kind: "idle" });
+    // Freeze context at click time — confirmation must match this binding,
+    // not whatever the wallet is on when the receipt lands.
+    const bound = ctxRef.current;
+    const epoch = epochRef.current;
+    setFlow({ kind: "collecting", ctx: bound, epoch });
     collectTx.writeContract({
       address: lockerAddr,
       abi: potatoFeeLockerAbi,
@@ -248,7 +256,9 @@ export function HarvestCard({
 
   function claimStanding() {
     if (!claimablesKnown) return;
-    startQueue(buildQueue(claimableWeth, claimableToken), undefined, ctx);
+    const bound = ctxRef.current;
+    const epoch = epochRef.current;
+    startQueue(buildQueue(claimableWeth, claimableToken), undefined, bound, epoch);
   }
 
   function handleClick() {
@@ -259,77 +269,79 @@ export function HarvestCard({
     collect();
   }
 
-  // Collect confirmed → wait for a fresh post-collect claimable snapshot.
-  // Only the creator who owns the current context may auto-claim.
+  // Collect confirmed under the same context/epoch that started it → explicit
+  // refetch of both claimables (never trust pre-collect cache or a timeout
+  // snapshot of zeros).
   useEffect(() => {
-    if (!collectTx.confirmed || !collectTx.hash || !isCreator) return;
     const f = flowRef.current;
-    if (
-      (f.kind === "await_claimables" && f.collectHash === collectTx.hash) ||
-      (f.kind === "claiming" && f.collectHash === collectTx.hash)
-    ) {
+    if (f.kind !== "collecting") return;
+    if (!collectTx.confirmed || !collectTx.hash) return;
+    if (!flowStillValid(f.ctx, f.epoch)) {
+      setFlow({ kind: "idle" });
       return;
     }
-    if (f.kind === "claiming" && !f.collectHash) return;
-
-    // Snapshot the context at collect-handling time; later transitions must match.
-    const bound = ctxRef.current;
+    // Only the creator may auto-claim; non-creators stop after collect.
+    if (!isCreator) {
+      setFlow({ kind: "idle" });
+      return;
+    }
     setFlow({
       kind: "await_claimables",
       collectHash: collectTx.hash,
-      minUpdatedAt: Date.now(),
-      ctx: bound,
+      ctx: f.ctx,
+      epoch: f.epoch,
     });
-  }, [collectTx.confirmed, collectTx.hash, isCreator]);
+  }, [collectTx.confirmed, collectTx.hash, isCreator, flowStillValid, flow]);
 
-  // Fresh claimables ready → freeze WETH-then-token queue.
+  // Explicit dual refetch → freeze queue from fresh results only.
   useEffect(() => {
     if (flow.kind !== "await_claimables") return;
-    if (!sameCtx(flow.ctx, ctx)) return; // context drifted — identity effect will idle
-    if (!claimablesKnown) return;
-    if (wethFetching || tokenFetching) return;
-    if (wethUpdatedAt < flow.minUpdatedAt || tokenUpdatedAt < flow.minUpdatedAt) return;
+    const { collectHash, ctx: bound, epoch } = flow;
+    let cancelled = false;
 
-    startQueue(buildQueue(claimableWeth, claimableToken), flow.collectHash, flow.ctx);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    flow,
-    ctx,
-    claimablesKnown,
-    claimableWeth,
-    claimableToken,
-    wethFetching,
-    tokenFetching,
-    wethUpdatedAt,
-    tokenUpdatedAt,
-  ]);
+    void (async () => {
+      try {
+        const [wRes, tRes] = await Promise.all([
+          refetchWethRef.current(),
+          refetchTokenRef.current(),
+        ]);
+        if (cancelled) return;
+        if (!flowStillValid(bound, epoch)) {
+          setFlow({ kind: "idle" });
+          return;
+        }
+        // Prefer refetch payload; fall back to 0 only when the read succeeded
+        // with an explicit undefined (no balance). On query error, abort rather
+        // than claim a partial wrong queue.
+        if (wRes.isError || tRes.isError) {
+          setFlow({ kind: "idle" });
+          return;
+        }
+        const wAmt = (wRes.data as bigint | undefined) ?? 0n;
+        const tAmt = (tRes.data as bigint | undefined) ?? 0n;
+        startQueue(buildQueue(wAmt, tAmt), collectHash, bound, epoch);
+      } catch {
+        if (!cancelled) setFlow({ kind: "idle" });
+      }
+    })();
 
-  // Fallback: read latest claimables from refs so a partial refresh still
-  // includes newly collected WETH even if one query stalled.
-  useEffect(() => {
-    if (flow.kind !== "await_claimables") return;
-    const collectHash = flow.collectHash;
-    const bound = flow.ctx;
-    const t = setTimeout(() => {
-      if (flowRef.current.kind !== "await_claimables") return;
-      if (flowRef.current.collectHash !== collectHash) return;
-      if (!sameCtx(bound, ctxRef.current)) return;
-      const snap = claimableRef.current;
-      startQueue(buildQueue(snap.weth, snap.token), collectHash, bound);
-    }, 8_000);
-    return () => clearTimeout(t);
+    return () => {
+      cancelled = true;
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [flow.kind === "await_claimables" ? flow.collectHash : null]);
 
   // Advance queue on active claim confirmation (each receipt once).
   useEffect(() => {
     if (flow.kind !== "claiming") return;
-    if (!sameCtx(flow.ctx, ctx)) return;
+    if (!flowStillValid(flow.ctx, flow.epoch)) {
+      setFlow({ kind: "idle" });
+      return;
+    }
     const activeTx = flow.active === "weth" ? claimWethTx : claimTokenTx;
     if (!activeTx.confirmed || !activeTx.hash) return;
     if (flow.advanced.has(activeTx.hash)) return;
 
-    const epoch = epochRef.current;
     const advanced = new Set(flow.advanced);
     advanced.add(activeTx.hash);
 
@@ -346,16 +358,17 @@ export function HarvestCard({
       collectHash: flow.collectHash,
       advanced,
       ctx: flow.ctx,
+      epoch: flow.epoch,
     });
-    writeClaim(next, flow.ctx, epoch);
+    writeClaim(next, flow.ctx, flow.epoch);
   }, [
     flow,
-    ctx,
     claimWethTx.confirmed,
     claimWethTx.hash,
     claimTokenTx.confirmed,
     claimTokenTx.hash,
     writeClaim,
+    flowStillValid,
   ]);
 
   useEffect(() => {
@@ -366,8 +379,16 @@ export function HarvestCard({
     }
   }, [flow, claimWethTx.reverted, claimWethTx.error, claimTokenTx.reverted, claimTokenTx.error]);
 
+  // Collect failed / rejected while in collecting → idle.
+  useEffect(() => {
+    if (flow.kind !== "collecting") return;
+    if (collectTx.reverted || collectTx.error) {
+      setFlow({ kind: "idle" });
+    }
+  }, [flow, collectTx.reverted, collectTx.error]);
+
   let label: string;
-  if (collectTx.busy) label = "Collecting…";
+  if (collectTx.busy || flow.kind === "collecting") label = "Collecting…";
   else if (flow.kind === "await_claimables") label = "Preparing claim…";
   else if (claimWethTx.busy || claimTokenTx.busy || flow.kind === "claiming") label = "Claiming…";
   else if (nothingToDo) label = "No fees yet";


### PR DESCRIPTION
## Summary

- Surfaces the creator's **token-side** claimable balance (`claimable[token][creator]`) in the LP Fees card alongside WETH.
- After `collect`, auto-chains `claim(WETH)` then `claim(token)` so creators receive both halves of their 50% fee share.
- Manual "Claim" when only standing balances remain also covers token-side fees.

Fixes #3

## Why

`HarvestCard` already showed uncollected token fees in the pool (via `useAccruedFees.tokenAmount`) and `collect` distributes both assets, but "Ready to claim" and the claim path only ever called `claim(weth)`. Token-side fees sat stranded in the locker.

## Test plan

- [x] `cd web && npx tsc --noEmit`
- [x] `cd web && npm run build`
- [ ] Creator with both sides accrued: Collect & claim → WETH then token claim txs; balances drop to zero
- [ ] Creator with only token-side standing balance: button shows "Claim {SYMBOL}" and withdraws ERC-20
- [ ] Non-creator still only sees "Collect fees" (no claim path)

## Attribution

Keeps the existing "Made by proofofpotato.com" footer credit.
