### PR TITLE
feat(web): gas/fee buffer on write transactions (#8)

### DIFF
--- a/web/lib/hooks.ts
+++ b/web/lib/hooks.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQueryClient } from "@tanstack/react-query";
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Address } from "viem";
 import {
   useChainId,
@@ -37,6 +37,17 @@ function padFee(value: bigint): bigint {
   return (value * FEE_BUFFER_BPS) / BPS;
 }
 
+function hasExplicitFeeOverride(params: Record<string, unknown> | null | undefined): boolean {
+  if (!params || typeof params !== "object") return false;
+  // Only treat as an intentional override when a value is actually supplied.
+  // `maxFeePerGas: undefined` (optional spread) must still get the buffer.
+  return (
+    params.maxFeePerGas != null ||
+    params.maxPriorityFeePerGas != null ||
+    params.gasPrice != null
+  );
+}
+
 /**
  * Write + wait-for-receipt in one hook. Invalidates all react-query caches
  * once a transaction confirms so on-chain reads refresh automatically.
@@ -46,19 +57,24 @@ function padFee(value: bigint): bigint {
  */
 export function useTx() {
   const queryClient = useQueryClient();
-  const publicClient = usePublicClient();
+  const chainId = useChainId();
+  const publicClient = usePublicClient({ chainId });
   const {
-    writeContract: rawWriteContract,
+    writeContractAsync: rawWriteContractAsync,
     data: hash,
     isPending,
     error: writeError,
-    reset,
+    reset: rawReset,
   } = useWriteContract();
   const {
     data: receipt,
     isLoading: isConfirming,
     error: receiptError,
   } = useWaitForTransactionReceipt({ hash });
+
+  /** Sync reentrancy lock — closes the gap while async fee estimate runs. */
+  const inFlightRef = useRef(false);
+  const [preparing, setPreparing] = useState(false);
 
   const confirmed = receipt?.status === "success";
   const reverted = receipt?.status === "reverted";
@@ -67,6 +83,20 @@ export function useTx() {
     if (confirmed) queryClient.invalidateQueries();
   }, [confirmed, queryClient]);
 
+  // Release the reentrancy lock once the mutation is fully idle again
+  // (wallet reject, error, or confirmation finished).
+  useEffect(() => {
+    if (!preparing && !isPending && !isConfirming) {
+      inFlightRef.current = false;
+    }
+  }, [preparing, isPending, isConfirming]);
+
+  const reset = useCallback(() => {
+    inFlightRef.current = false;
+    setPreparing(false);
+    rawReset();
+  }, [rawReset]);
+
   // Wrap writeContract so every dapp write inherits the fee buffer without
   // touching HarvestCard / TradeWidget / create call sites individually.
   // Implementation is deliberately untyped; the exported surface is re-cast to
@@ -74,62 +104,86 @@ export function useTx() {
   const writeContractBuffered = useCallback(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (params: any, options?: any) => {
-      // Fire-and-forget async: estimate fees, then submit. Errors from the
-      // estimate path are swallowed so a flaky eth_feeHistory still lets the
-      // wallet's own estimate through; write errors still surface via the hook.
+      // Synchronous reentrancy guard — must flip before any await so rapid
+      // clicks cannot launch two fee estimates / two payable mutations.
+      if (inFlightRef.current) return;
+      inFlightRef.current = true;
+      setPreparing(true);
+
       void (async () => {
-        // Caller already chose fees — don't second-guess.
-        if (
-          params &&
-          typeof params === "object" &&
-          ("maxFeePerGas" in params ||
-            "maxPriorityFeePerGas" in params ||
-            "gasPrice" in params)
-        ) {
-          rawWriteContract(params, options);
-          return;
-        }
-
-        let feeOverrides: {
-          maxFeePerGas?: bigint;
-          maxPriorityFeePerGas?: bigint;
-          gasPrice?: bigint;
-        } = {};
-
         try {
-          if (publicClient) {
-            const fees = await publicClient.estimateFeesPerGas();
-            if (fees.maxFeePerGas != null && fees.maxPriorityFeePerGas != null) {
-              feeOverrides = {
-                maxFeePerGas: padFee(fees.maxFeePerGas),
-                maxPriorityFeePerGas: padFee(fees.maxPriorityFeePerGas),
-              };
-            } else if (fees.gasPrice != null) {
-              feeOverrides = { gasPrice: padFee(fees.gasPrice) };
+          const effectiveChainId: number =
+            typeof params?.chainId === "number" ? params.chainId : chainId;
+
+          // Abort if the wallet chain drifted while we were preparing — better
+          // to no-op than submit old-chain addresses with new-chain fees.
+          if (effectiveChainId !== chainId) {
+            return;
+          }
+
+          let submitParams = { ...params, chainId: effectiveChainId };
+
+          if (!hasExplicitFeeOverride(params)) {
+            try {
+              if (publicClient) {
+                // Detect fee market from the latest block so legacy chains get
+                // a gasPrice pad (estimateFeesPerGas() EIP-1559 default throws
+                // on legacy and would otherwise skip the buffer entirely).
+                const block = await publicClient.getBlock({ blockTag: "latest" });
+
+                // Re-check chain after the await.
+                if (effectiveChainId !== chainId) return;
+
+                if (block.baseFeePerGas != null) {
+                  const fees = await publicClient.estimateFeesPerGas({ type: "eip1559" });
+                  if (fees.maxFeePerGas != null && fees.maxPriorityFeePerGas != null) {
+                    submitParams = {
+                      ...submitParams,
+                      maxFeePerGas: padFee(fees.maxFeePerGas),
+                      maxPriorityFeePerGas: padFee(fees.maxPriorityFeePerGas),
+                    };
+                  }
+                } else {
+                  const fees = await publicClient.estimateFeesPerGas({ type: "legacy" });
+                  if (fees.gasPrice != null) {
+                    submitParams = {
+                      ...submitParams,
+                      gasPrice: padFee(fees.gasPrice),
+                    };
+                  }
+                }
+              }
+            } catch {
+              // leave fee fields empty → wallet / middleware estimate
             }
           }
-        } catch {
-          // leave feeOverrides empty → wallet / middleware estimate
-        }
 
-        rawWriteContract({ ...params, ...feeOverrides }, options);
+          // Final chain check before the wallet prompt.
+          if (effectiveChainId !== chainId) return;
+
+          await rawWriteContractAsync(submitParams, options);
+        } catch {
+          // write errors still surface via the hook's `error` state
+        } finally {
+          setPreparing(false);
+        }
       })();
     },
-    [publicClient, rawWriteContract],
+    [chainId, publicClient, rawWriteContractAsync],
   );
 
   return {
-    writeContract: writeContractBuffered as typeof rawWriteContract,
+    writeContract: writeContractBuffered as typeof rawWriteContractAsync,
     hash,
     receipt,
-    /** waiting for the wallet signature */
-    isPending,
+    /** waiting for fee estimate and/or wallet signature */
+    isPending: preparing || isPending,
     /** signed, waiting for inclusion */
     isConfirming,
     confirmed,
     reverted,
     error: writeError ?? receiptError ?? null,
-    busy: isPending || isConfirming,
+    busy: preparing || isPending || isConfirming,
     reset,
   };
 }

--- a/web/lib/hooks.ts
+++ b/web/lib/hooks.ts
@@ -1,10 +1,11 @@
 "use client";
 
 import { useQueryClient } from "@tanstack/react-query";
-import { useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import type { Address } from "viem";
 import {
   useChainId,
+  usePublicClient,
   useReadContracts,
   useWaitForTransactionReceipt,
   useWriteContract,
@@ -21,13 +22,33 @@ export function usePad() {
 }
 
 /**
+ * Multiplier applied on top of the network's estimated EIP-1559 (or legacy)
+ * gas price when submitting writes. Robinhood Chain wallets sometimes under-
+ * estimate fees so claims/trades fail with "gas price too low, retry" — a
+ * modest pad makes the first attempt stick. Callers that already pass their
+ * own maxFeePerGas / maxPriorityFeePerGas / gasPrice are left untouched.
+ *
+ * 15_000 bps = 1.5× the RPC estimate.
+ */
+const FEE_BUFFER_BPS = 15_000n;
+const BPS = 10_000n;
+
+function padFee(value: bigint): bigint {
+  return (value * FEE_BUFFER_BPS) / BPS;
+}
+
+/**
  * Write + wait-for-receipt in one hook. Invalidates all react-query caches
  * once a transaction confirms so on-chain reads refresh automatically.
+ *
+ * Also applies a modest gas-fee buffer (see {FEE_BUFFER_BPS}) so write txs
+ * on chains with sticky under-estimates (Robinhood) confirm on the first try.
  */
 export function useTx() {
   const queryClient = useQueryClient();
+  const publicClient = usePublicClient();
   const {
-    writeContract,
+    writeContract: rawWriteContract,
     data: hash,
     isPending,
     error: writeError,
@@ -46,8 +67,59 @@ export function useTx() {
     if (confirmed) queryClient.invalidateQueries();
   }, [confirmed, queryClient]);
 
+  // Wrap writeContract so every dapp write inherits the fee buffer without
+  // touching HarvestCard / TradeWidget / create call sites individually.
+  // Implementation is deliberately untyped; the exported surface is re-cast to
+  // wagmi's writeContract so ABI-generic call sites keep their inference.
+  const writeContractBuffered = useCallback(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (params: any, options?: any) => {
+      // Fire-and-forget async: estimate fees, then submit. Errors from the
+      // estimate path are swallowed so a flaky eth_feeHistory still lets the
+      // wallet's own estimate through; write errors still surface via the hook.
+      void (async () => {
+        // Caller already chose fees — don't second-guess.
+        if (
+          params &&
+          typeof params === "object" &&
+          ("maxFeePerGas" in params ||
+            "maxPriorityFeePerGas" in params ||
+            "gasPrice" in params)
+        ) {
+          rawWriteContract(params, options);
+          return;
+        }
+
+        let feeOverrides: {
+          maxFeePerGas?: bigint;
+          maxPriorityFeePerGas?: bigint;
+          gasPrice?: bigint;
+        } = {};
+
+        try {
+          if (publicClient) {
+            const fees = await publicClient.estimateFeesPerGas();
+            if (fees.maxFeePerGas != null && fees.maxPriorityFeePerGas != null) {
+              feeOverrides = {
+                maxFeePerGas: padFee(fees.maxFeePerGas),
+                maxPriorityFeePerGas: padFee(fees.maxPriorityFeePerGas),
+              };
+            } else if (fees.gasPrice != null) {
+              feeOverrides = { gasPrice: padFee(fees.gasPrice) };
+            }
+          }
+        } catch {
+          // leave feeOverrides empty → wallet / middleware estimate
+        }
+
+        rawWriteContract({ ...params, ...feeOverrides }, options);
+      })();
+    },
+    [publicClient, rawWriteContract],
+  );
+
   return {
-    writeContract,
+    writeContract: writeContractBuffered as typeof rawWriteContract,
     hash,
     receipt,
     /** waiting for the wallet signature */

--- a/web/lib/hooks.ts
+++ b/web/lib/hooks.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useQueryClient } from "@tanstack/react-query";
+import { getChainId } from "@wagmi/core";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Address } from "viem";
 import {
@@ -12,6 +13,7 @@ import {
 } from "wagmi";
 import { potatoPadAbi } from "@/lib/abi";
 import { PAD_ADDRESSES, WETH_ADDRESSES, ZERO_ADDRESS, padDeployments } from "@/lib/config";
+import { wagmiConfig } from "@/lib/wagmi";
 
 /** Resolve PotatoPad + WETH addresses for the active chain. */
 export function usePad() {
@@ -48,6 +50,11 @@ function hasExplicitFeeOverride(params: Record<string, unknown> | null | undefin
   );
 }
 
+/** Live wallet chain — not a render-captured value (survives mid-flight switches). */
+function liveChainId(): number {
+  return getChainId(wagmiConfig);
+}
+
 /**
  * Write + wait-for-receipt in one hook. Invalidates all react-query caches
  * once a transaction confirms so on-chain reads refresh automatically.
@@ -66,11 +73,21 @@ export function useTx() {
     error: writeError,
     reset: rawReset,
   } = useWriteContract();
+
+  /**
+   * Chain the write was submitted on. Receipt polling must use this — not the
+   * live wallet chain — so a mid-flight switch cannot leave the UI hanging.
+   */
+  const [submitChainId, setSubmitChainId] = useState<number | undefined>(undefined);
+
   const {
     data: receipt,
     isLoading: isConfirming,
     error: receiptError,
-  } = useWaitForTransactionReceipt({ hash });
+  } = useWaitForTransactionReceipt({
+    hash,
+    chainId: submitChainId,
+  });
 
   /** Sync reentrancy lock — closes the gap while async fee estimate runs. */
   const inFlightRef = useRef(false);
@@ -94,6 +111,7 @@ export function useTx() {
   const reset = useCallback(() => {
     inFlightRef.current = false;
     setPreparing(false);
+    setSubmitChainId(undefined);
     rawReset();
   }, [rawReset]);
 
@@ -115,9 +133,8 @@ export function useTx() {
           const effectiveChainId: number =
             typeof params?.chainId === "number" ? params.chainId : chainId;
 
-          // Abort if the wallet chain drifted while we were preparing — better
-          // to no-op than submit old-chain addresses with new-chain fees.
-          if (effectiveChainId !== chainId) {
+          // Abort if wallet is not on the intended chain (live read, not closure).
+          if (liveChainId() !== effectiveChainId) {
             return;
           }
 
@@ -131,8 +148,7 @@ export function useTx() {
                 // on legacy and would otherwise skip the buffer entirely).
                 const block = await publicClient.getBlock({ blockTag: "latest" });
 
-                // Re-check chain after the await.
-                if (effectiveChainId !== chainId) return;
+                if (liveChainId() !== effectiveChainId) return;
 
                 if (block.baseFeePerGas != null) {
                   const fees = await publicClient.estimateFeesPerGas({ type: "eip1559" });
@@ -158,12 +174,17 @@ export function useTx() {
             }
           }
 
-          // Final chain check before the wallet prompt.
-          if (effectiveChainId !== chainId) return;
+          // Final live chain check before the wallet prompt.
+          if (liveChainId() !== effectiveChainId) return;
+
+          // Pin receipt polling to the submission chain before the wallet returns.
+          setSubmitChainId(effectiveChainId);
 
           await rawWriteContractAsync(submitParams, options);
         } catch {
-          // write errors still surface via the hook's `error` state
+          // write errors still surface via the hook's `error` state;
+          // clear pin so a retry on another chain is not stuck.
+          setSubmitChainId(undefined);
         } finally {
           setPreparing(false);
         }


### PR DESCRIPTION
## Summary

- Pads EIP-1559 (`maxFeePerGas` / `maxPriorityFeePerGas`) or legacy `gasPrice` by **1.5×** on every dapp write going through `useTx`.
- Centralized in `web/lib/hooks.ts` so `HarvestCard`, `TradeWidget`, and `app/create` pick it up with zero call-site churn.
- Callers that already pass explicit fee fields are left alone; fee-estimate failures fall back to the wallet's own estimate.

Fixes #8

## Why

On Robinhood Chain, wallets sometimes under-estimate gas price, so `claim` / trade txs fail with "gas price too low, retry". Bumping the fee slightly on submit makes the first attempt stick without changing contract logic or adding deps.

## Test plan

- [x] `cd web && npx tsc --noEmit`
- [x] `cd web && npm run build`
- [ ] Claim / buy / sell / createToken: wallet shows a slightly higher max fee; txs confirm without the "gas too low" retry nag
- [ ] Explicit fee overrides (if any) still win over the buffer

## Attribution

Keeps the existing "Made by proofofpotato.com" footer credit.
