### PR TITLE
feat(web): blacklist existing on-chain names/tickers on create (#30)

### DIFF
--- a/web/app/api/tokens/route.ts
+++ b/web/app/api/tokens/route.ts
@@ -7,6 +7,13 @@ import { loadFeed } from "@/lib/tokenFeed";
  *
  * `private, no-store` so shared caches never freeze `servedAt` (rolling windows
  * and stale labels depend on a per-response clock).
+ *
+ * Query:
+ * - `force=1` — bypass the normal 90s TTL (Plant create pre-submit revalidation).
+ *   Discover should omit this so the shared cache still absorbs traffic.
+ *   New forced *scans* are rate-limited (global + per-IP) inside `loadFeed` after
+ *   forceInFlight coalescing; over limit returns `unavailable` so create stays
+ *   fail-closed without free RPC DoS.
  */
 
 export const runtime = "nodejs";
@@ -15,9 +22,56 @@ const CACHE_HEADERS = {
   "Cache-Control": "private, no-store",
 };
 
-export async function GET() {
+// Forced full-history multi-pad scans are expensive. Same pattern as /api/holders:
+// per-IP is soft (X-Forwarded-For spoofable); GLOBAL is the unspoofable ceiling.
+const FORCE_RL_WINDOW_MS = 60_000;
+const FORCE_RL_MAX_PER_IP = 6;
+const FORCE_RL_MAX_GLOBAL =
+  Number(process.env.TOKENS_FORCE_MAX_GLOBAL_PER_WINDOW) || 30;
+const forceIpHits = new Map<string, number[]>();
+let forceGlobalHits: number[] = [];
+
+function forceRateLimited(ip: string): boolean {
+  const now = Date.now();
+  // Check BEFORE recording so over-limit traffic does not grow the arrays.
+  forceGlobalHits = forceGlobalHits.filter((t) => now - t < FORCE_RL_WINDOW_MS);
+  if (forceGlobalHits.length >= FORCE_RL_MAX_GLOBAL) return true;
+
+  const recent = (forceIpHits.get(ip) ?? []).filter(
+    (t) => now - t < FORCE_RL_WINDOW_MS,
+  );
+  if (recent.length >= FORCE_RL_MAX_PER_IP) return true;
+
+  forceGlobalHits.push(now);
+  recent.push(now);
+  forceIpHits.set(ip, recent);
+  if (forceIpHits.size > 5000) {
+    for (const [k, v] of forceIpHits) {
+      if (v.every((t) => now - t >= FORCE_RL_WINDOW_MS)) forceIpHits.delete(k);
+    }
+  }
+  return false;
+}
+
+function clientIp(request: Request): string {
+  return (
+    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+    request.headers.get("x-real-ip") ||
+    "unknown"
+  );
+}
+
+export async function GET(request: Request) {
   // loadFeed soft-degrades on RPC failure (last good payload, or unavailable),
   // so we always return HTTP 200 and the UI degrades gracefully.
-  const payload = await loadFeed();
+  const force = new URL(request.url).searchParams.get("force") === "1";
+  const ip = clientIp(request);
+
+  const payload = await loadFeed({
+    force,
+    // Only charged when loadFeed is about to start a new forced scan
+    // (after forceInFlight coalesce).
+    consumeForceQuota: force ? () => forceRateLimited(ip) : undefined,
+  });
   return NextResponse.json(payload, { headers: CACHE_HEADERS });
 }

--- a/web/app/create/page.tsx
+++ b/web/app/create/page.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { useQueryClient } from "@tanstack/react-query";
-import { Loader2 } from "lucide-react";
+import { AlertTriangle, Loader2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useState, type ChangeEvent, type FormEvent } from "react";
 import { bytesToHex, decodeEventLog, parseEther } from "viem";
 import { potatoPadAbi } from "@/lib/abi";
+import { robinhoodChain } from "@/lib/config";
 import { usePad, useTx } from "@/lib/hooks";
 import { useAncientTokens } from "@/lib/ancient";
 import { formatEth, resolveImageUri, tryParseEther } from "@/lib/format";
@@ -35,6 +36,109 @@ const CREATOR_HALF_PCT = 50;
  */
 const MAX_CREATOR_CUT_PCT = CREATOR_HALF_PCT - 5;
 
+/** Per-attempt timeout for the existing-ticker feed. */
+const TAKEN_FEED_TIMEOUT_MS = 8_000;
+
+/** Attempts before fail-closed: initial fetch + one silent retry. */
+const TAKEN_FEED_MAX_ATTEMPTS = 2;
+
+/**
+ * Canonical comparison key for name/ticker blacklist.
+ * NFC + en-US uppercasing folds case more reliably than raw toLowerCase
+ * (e.g. Greek sigma forms that lower differently but upper the same).
+ */
+function foldKey(value: string): string {
+  return value.trim().normalize("NFC").toLocaleUpperCase("en-US");
+}
+
+type TakenSets = { names: Set<string>; symbols: Set<string> };
+
+/**
+ * Ready snapshot, still loading, or hard-failed after retries.
+ * Fail-closed: we never plant against an unverified empty blacklist.
+ */
+type TakenFeedState =
+  | { status: "loading" }
+  | { status: "ready"; chainId: number; taken: TakenSets }
+  | { status: "failed" };
+
+/**
+ * Fresh name/ticker snapshot for create validation.
+ * Bypasses Discover's localStorage + browser HTTP cache so a returning user
+ * cannot submit a ticker planted after their last Discover visit.
+ * `/api/tokens` only indexes Robinhood — callers must only enable on that chain.
+ *
+ * Throws on timeout, network error, non-OK, or `unavailable` so the caller
+ * can retry once then fail closed (utility over soft-open create).
+ */
+async function fetchTakenTickers(signal: AbortSignal): Promise<TakenSets> {
+  // cache: "no-store" + bust query so neither browser nor CDN soft-stale wins.
+  const res = await fetch(`/api/tokens?createCheck=${Date.now()}`, {
+    cache: "no-store",
+    signal,
+  });
+  if (!res.ok) throw new Error(`ticker feed HTTP ${res.status}`);
+  const json = (await res.json()) as {
+    creations?: Array<{ name?: string; symbol?: string }>;
+    unavailable?: boolean;
+  };
+  if (json.unavailable) throw new Error("ticker feed unavailable");
+  const names = new Set<string>();
+  const symbols = new Set<string>();
+  for (const c of json.creations ?? []) {
+    if (c.name) names.add(foldKey(c.name));
+    if (c.symbol) symbols.add(foldKey(c.symbol));
+  }
+  return { names, symbols };
+}
+
+/** One timed attempt; aborts after TAKEN_FEED_TIMEOUT_MS. */
+async function fetchTakenTickersOnce(
+  parentSignal?: AbortSignal,
+): Promise<TakenSets> {
+  const controller = new AbortController();
+  const onParentAbort = () => controller.abort();
+  if (parentSignal) {
+    if (parentSignal.aborted) {
+      controller.abort();
+    } else {
+      parentSignal.addEventListener("abort", onParentAbort, { once: true });
+    }
+  }
+  const timer = setTimeout(() => controller.abort(), TAKEN_FEED_TIMEOUT_MS);
+  try {
+    return await fetchTakenTickers(controller.signal);
+  } finally {
+    clearTimeout(timer);
+    parentSignal?.removeEventListener("abort", onParentAbort);
+  }
+}
+
+/**
+ * Timed fetch with one silent retry. Unmount/chain-change aborts via parentSignal.
+ * Second failure propagates so the UI can fail closed.
+ */
+async function fetchTakenTickersWithRetry(
+  parentSignal?: AbortSignal,
+): Promise<TakenSets> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= TAKEN_FEED_MAX_ATTEMPTS; attempt++) {
+    if (parentSignal?.aborted) throw new DOMException("Aborted", "AbortError");
+    try {
+      return await fetchTakenTickersOnce(parentSignal);
+    } catch (err) {
+      lastError = err;
+      // Don't retry if the page effect cleaned up (chain switch / unmount).
+      if (parentSignal?.aborted) throw err;
+      // Attempt 1 failed: loop silently into attempt 2.
+      // Attempt 2 failed: fall through and rethrow.
+    }
+  }
+  throw lastError instanceof Error
+    ? lastError
+    : new Error("ticker feed failed");
+}
+
 const inputCls =
   "w-full rounded-lg border border-neutral-800 bg-black px-3 py-2.5 text-sm text-neutral-100 placeholder-neutral-700 outline-none transition-colors focus:border-neutral-600";
 const labelCls = "text-[10px] font-bold uppercase tracking-wider text-neutral-500";
@@ -45,6 +149,9 @@ export default function CreatePage() {
   const { pad, chainId, isDeployed } = usePad();
   const tx = useTx();
   const { tokens: ancientTokens } = useAncientTokens();
+  // /api/tokens only indexes Robinhood; on other chains skip the soft blacklist
+  // so we never false-block against the wrong network's tickers.
+  const feedApplies = chainId === robinhoodChain.id;
 
   const [name, setName] = useState("");
   const [symbol, setSymbol] = useState("");
@@ -55,6 +162,46 @@ export default function CreatePage() {
   const [devBuy, setDevBuy] = useState("");
   const [uploading, setUploading] = useState(false);
   const [uploadErr, setUploadErr] = useState("");
+  // loading → ready | failed. Never open create against an empty blacklist
+  // when the feed could not be verified (timeout / network / unavailable).
+  const [takenFeed, setTakenFeed] = useState<TakenFeedState>({
+    status: "loading",
+  });
+
+  // Mount / chain-change: revalidate against a fresh feed for Robinhood.
+  // Attempt 1 → silent retry → fail closed (toast + force restart).
+  useEffect(() => {
+    if (!feedApplies) {
+      // Off Robinhood: no ticker index; don't gate create.
+      setTakenFeed({
+        status: "ready",
+        chainId,
+        taken: { names: new Set(), symbols: new Set() },
+      });
+      return;
+    }
+    let cancelled = false;
+    setTakenFeed({ status: "loading" });
+    const controller = new AbortController();
+
+    void (async () => {
+      try {
+        const next = await fetchTakenTickersWithRetry(controller.signal);
+        if (!cancelled) {
+          setTakenFeed({ status: "ready", chainId, taken: next });
+        }
+      } catch {
+        if (!cancelled && !controller.signal.aborted) {
+          setTakenFeed({ status: "failed" });
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [feedApplies, chainId]);
 
   // Holder rewards: share the creator's half of the fees with everyone holding.
   const [rewardsOn, setRewardsOn] = useState(false);
@@ -81,6 +228,23 @@ export default function CreatePage() {
     }
   }
 
+  const taken =
+    takenFeed.status === "ready" && takenFeed.chainId === chainId
+      ? takenFeed.taken
+      : null;
+  const feedFailed = feedApplies && takenFeed.status === "failed";
+  const waitingOnFeed = feedApplies && takenFeed.status === "loading";
+
+  const nameKey = foldKey(name);
+  const symbolKey = foldKey(symbol);
+  const nameTaken =
+    feedApplies && !!taken && nameKey.length > 0 && taken.names.has(nameKey);
+  const symbolTaken =
+    feedApplies &&
+    !!taken &&
+    symbolKey.length > 0 &&
+    taken.symbols.has(symbolKey);
+
   const devBuyWei = devBuy.trim() === "" ? 0n : tryParseEther(devBuy);
   const devBuyTooLarge = devBuyWei !== undefined && devBuyWei > MAX_DEV_BUY_WEI;
 
@@ -105,6 +269,10 @@ export default function CreatePage() {
     symbol.trim().length > 0 &&
     image.trim().length > 0 &&
     !vampBlocked &&
+    !nameTaken &&
+    !symbolTaken &&
+    !waitingOnFeed &&
+    !feedFailed &&
     devBuyWei !== undefined &&
     !devBuyTooLarge;
 
@@ -176,12 +344,53 @@ export default function CreatePage() {
       ? "Planting…"
       : tx.confirmed
         ? "Planted"
-        : vampBlocked
-          ? "Deployment restricted"
-          : "Plant token";
+        : feedFailed
+          ? "Verification failed"
+          : waitingOnFeed
+            ? "Checking tickers…"
+            : vampBlocked
+              ? "Deployment restricted"
+              : nameTaken || symbolTaken
+                ? "Name or ticker taken"
+                : "Plant token";
+
+  const nameFieldBlocked = nameBlocked || nameTaken;
+  const symbolFieldBlocked = symbolBlocked || symbolTaken;
 
   return (
     <div className="mx-auto max-w-4xl">
+      {/* Fail-closed toast: utility > journey when the ticker feed can't be verified. */}
+      {feedFailed && (
+        <div
+          role="alert"
+          className="fixed inset-x-0 top-0 z-50 flex justify-center px-4 pt-4"
+        >
+          <div className="flex w-full max-w-md items-start gap-3 rounded-xl border border-rose-500/40 bg-neutral-950/95 p-4 shadow-lg shadow-black/40 backdrop-blur">
+            <AlertTriangle
+              className="mt-0.5 h-5 w-5 shrink-0 text-rose-400"
+              aria-hidden
+            />
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-semibold text-rose-300">
+                Couldn&apos;t verify existing tickers
+              </p>
+              <p className="mt-1 text-xs text-neutral-400">
+                The name/ticker check failed twice (timeout or feed error). Plant
+                is blocked so we never ship a duplicate under a blind empty list.
+                Reload to restart the process.
+              </p>
+              <button
+                type="button"
+                className="mt-3 rounded-lg bg-rose-500/20 px-3 py-1.5 text-xs font-semibold text-rose-200 transition-colors hover:bg-rose-500/30"
+                onClick={() => window.location.reload()}
+              >
+                Reload page
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
       <ConnectGate>
         <div className="grid grid-cols-1 items-start gap-6 md:grid-cols-5">
           {/* LEFT: input matrix */}
@@ -194,18 +403,32 @@ export default function CreatePage() {
             </div>
 
             <form id="plant-form" onSubmit={onSubmit} className="space-y-4">
+              {feedFailed && (
+                <div className="rounded-lg border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-xs text-rose-400">
+                  Name/ticker verification failed. Reload the page to try again —
+                  create stays blocked until the feed is confirmed.
+                </div>
+              )}
+
               <div className="space-y-1.5">
                 <label htmlFor="name" className={labelCls}>
                   Token name
                 </label>
                 <input
                   id="name"
-                  className={`${inputCls} ${nameBlocked ? "border-rose-900/60 bg-rose-950/10 text-rose-300" : ""}`}
+                  className={`${inputCls} ${nameFieldBlocked ? "border-rose-900/60 bg-rose-950/10 text-rose-300" : ""}`}
                   placeholder="Mashed Potato"
                   value={name}
                   maxLength={48}
                   onChange={(e) => setName(e.target.value)}
+                  aria-invalid={nameFieldBlocked || undefined}
+                  disabled={feedFailed}
                 />
+                {nameTaken && (
+                  <p className="mt-1 text-xs text-rose-400">
+                    That name is already deployed on-chain. Pick another.
+                  </p>
+                )}
               </div>
 
               <div className="space-y-1.5">
@@ -214,12 +437,22 @@ export default function CreatePage() {
                 </label>
                 <input
                   id="symbol"
-                  className={`${inputCls} font-mono uppercase ${symbolBlocked ? "border-rose-900/60 bg-rose-950/10 text-rose-300" : ""}`}
+                  className={`${inputCls} font-mono uppercase ${symbolFieldBlocked ? "border-rose-900/60 bg-rose-950/10 text-rose-300" : ""}`}
                   placeholder="MASH"
                   value={symbol}
                   maxLength={12}
                   onChange={(e) => setSymbol(e.target.value)}
+                  aria-invalid={symbolFieldBlocked || undefined}
+                  disabled={feedFailed}
                 />
+                {symbolTaken && (
+                  <p className="mt-1 text-xs text-rose-400">
+                    Ticker ${symbolKey} is already deployed on-chain. Pick another.
+                  </p>
+                )}
+                {waitingOnFeed && (
+                  <p className="mt-1 text-xs text-neutral-500">Checking existing tickers…</p>
+                )}
               </div>
 
               <div className="space-y-1.5">
@@ -241,7 +474,7 @@ export default function CreatePage() {
                       type="file"
                       accept="image/png,image/jpeg,image/gif,image/webp,image/svg+xml"
                       className="hidden"
-                      disabled={uploading}
+                      disabled={uploading || feedFailed}
                       onChange={handleUpload}
                     />
                   </label>
@@ -263,6 +496,7 @@ export default function CreatePage() {
                     placeholder="https://x.com/…"
                     value={twitter}
                     onChange={(e) => setTwitter(e.target.value)}
+                    disabled={feedFailed}
                   />
                 </div>
                 <div className="space-y-1.5">
@@ -275,6 +509,7 @@ export default function CreatePage() {
                     placeholder="https://t.me/…"
                     value={telegram}
                     onChange={(e) => setTelegram(e.target.value)}
+                    disabled={feedFailed}
                   />
                 </div>
               </div>
@@ -289,6 +524,7 @@ export default function CreatePage() {
                   placeholder="https://…"
                   value={website}
                   onChange={(e) => setWebsite(e.target.value)}
+                  disabled={feedFailed}
                 />
               </div>
 
@@ -306,13 +542,14 @@ export default function CreatePage() {
                   inputMode="decimal"
                   value={devBuy}
                   onChange={(e) => setDevBuy(e.target.value)}
+                  disabled={feedFailed}
                 />
                 {devBuy.trim() !== "" && devBuyWei === undefined && (
                   <p className="text-xs text-rose-400">Enter a valid ETH amount.</p>
                 )}
                 {devBuyTooLarge && (
                   <p className="text-xs text-rose-400">
-                    Capped at {formatEth(MAX_DEV_BUY_WEI)} ETH (5% of supply) during the anti-snipe
+                    Capped at {formatEth(MAX_DEV_BUY_WEI)} ETH (2% of supply) during the anti-snipe
                     window.
                   </p>
                 )}
@@ -324,6 +561,7 @@ export default function CreatePage() {
                   <button
                     type="button"
                     onClick={() => setRewardsOn(false)}
+                    disabled={feedFailed}
                     className={`rounded-lg border px-3 py-2.5 text-left transition-colors ${
                       rewardsOn
                         ? "border-neutral-800 bg-black hover:border-neutral-700"
@@ -338,6 +576,7 @@ export default function CreatePage() {
                   <button
                     type="button"
                     onClick={() => setRewardsOn(true)}
+                    disabled={feedFailed}
                     className={`rounded-lg border px-3 py-2.5 text-left transition-colors ${
                       rewardsOn
                         ? "border-amber-500/60 bg-amber-500/10"
@@ -370,6 +609,7 @@ export default function CreatePage() {
                       value={creatorCutPct}
                       onChange={(e) => setCreatorCutPct(Number(e.target.value))}
                       className="w-full accent-amber-500"
+                      disabled={feedFailed}
                     />
 
                     {/* Live split preview: the three ways a fee can go. */}
@@ -424,14 +664,24 @@ export default function CreatePage() {
                   an original.
                 </p>
               </div>
+            ) : nameTaken || symbolTaken ? (
+              <div className="space-y-1.5 rounded-xl border border-rose-900/40 bg-rose-950/10 p-4">
+                <h4 className="font-mono text-xs font-bold uppercase tracking-wider text-rose-400">
+                  Existing ticker · blocked
+                </h4>
+                <p className="text-[11px] leading-relaxed text-rose-300/80">
+                  That name or ticker is already live on the pad feed. Soft-block only — the
+                  contract still does not enforce uniqueness. Pick an original.
+                </p>
+              </div>
             ) : (
               <div className="space-y-1.5 rounded-xl border border-neutral-800/60 bg-neutral-950 p-4">
                 <h4 className="font-mono text-xs font-bold uppercase tracking-wider text-neutral-400">
                   Anti-vampire shield · active
                 </h4>
                 <p className="text-[11px] leading-relaxed text-neutral-500">
-                  Names and symbols are checked against curated ancient runners, on-chain and in this
-                  form, so copycats can&apos;t vamp the originals.
+                  Names and symbols are checked against curated ancient runners and the live
+                  on-chain launch feed, so copycats can&apos;t vamp the originals.
                 </p>
               </div>
             )}

--- a/web/app/create/page.tsx
+++ b/web/app/create/page.tsx
@@ -3,7 +3,14 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { AlertTriangle, Loader2 } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useEffect, useMemo, useState, type ChangeEvent, type FormEvent } from "react";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type FormEvent,
+} from "react";
 import { bytesToHex, decodeEventLog, parseEther } from "viem";
 import { potatoPadAbi } from "@/lib/abi";
 import { robinhoodChain } from "@/lib/config";
@@ -42,6 +49,16 @@ const TAKEN_FEED_TIMEOUT_MS = 8_000;
 /** Attempts before fail-closed: initial fetch + one silent retry. */
 const TAKEN_FEED_MAX_ATTEMPTS = 2;
 
+/** Cap creations processed client-side (malicious / oversized feed DoS bound). */
+const MAX_FEED_CREATIONS = 10_000;
+
+/**
+ * Max source length for a name/symbol key from the feed.
+ * Form name max is 48; historical on-chain symbols may exceed the form's 12-char
+ * symbol input — still index them so they cannot be reused as a new name.
+ */
+const MAX_KEY_SOURCE_LEN = 64;
+
 /**
  * Canonical comparison key for name/ticker blacklist.
  * NFC + en-US uppercasing folds case more reliably than raw toLowerCase
@@ -51,7 +68,11 @@ function foldKey(value: string): string {
   return value.trim().normalize("NFC").toLocaleUpperCase("en-US");
 }
 
-type TakenSets = { names: Set<string>; symbols: Set<string> };
+/**
+ * Combined name+symbol key set. Issue #30: every existing name and ticker is
+ * blocked "when used" — so a new symbol cannot reuse an existing name and vice versa.
+ */
+type TakenKeys = { keys: Set<string> };
 
 /**
  * Ready snapshot, still loading, or hard-failed after retries.
@@ -59,43 +80,90 @@ type TakenSets = { names: Set<string>; symbols: Set<string> };
  */
 type TakenFeedState =
   | { status: "loading" }
-  | { status: "ready"; chainId: number; taken: TakenSets }
+  | { status: "ready"; chainId: number; taken: TakenKeys }
   | { status: "failed" };
+
+type FeedJson = {
+  creations?: unknown;
+  unavailable?: unknown;
+  state?: unknown;
+  scanCompletedAt?: unknown;
+};
+
+/**
+ * Parse + sanitize a /api/tokens payload for create validation.
+ * Fail closed unless state is exactly "fresh" (reject stale + unavailable).
+ */
+function parseTakenFromFeed(json: FeedJson): TakenKeys {
+  if (json.unavailable === true) {
+    throw new Error("ticker feed unavailable");
+  }
+  // Create must not treat warm soft-degrade as verified.
+  if (json.state !== "fresh") {
+    throw new Error(
+      `ticker feed not fresh (state=${String(json.state ?? "missing")})`,
+    );
+  }
+  const raw = Array.isArray(json.creations) ? json.creations : [];
+  // Fail closed if the feed is larger than we are willing to verify — truncation
+  // would accept an incomplete blacklist as "fresh".
+  if (raw.length > MAX_FEED_CREATIONS) {
+    throw new Error(`ticker feed too large (${raw.length})`);
+  }
+  const keys = new Set<string>();
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") continue;
+    const c = entry as { name?: unknown; symbol?: unknown };
+    if (
+      typeof c.name === "string" &&
+      c.name.length > 0 &&
+      c.name.length <= MAX_KEY_SOURCE_LEN
+    ) {
+      const k = foldKey(c.name);
+      if (k) keys.add(k);
+    }
+    if (
+      typeof c.symbol === "string" &&
+      c.symbol.length > 0 &&
+      c.symbol.length <= MAX_KEY_SOURCE_LEN
+    ) {
+      const k = foldKey(c.symbol);
+      if (k) keys.add(k);
+    }
+  }
+  return { keys };
+}
 
 /**
  * Fresh name/ticker snapshot for create validation.
- * Bypasses Discover's localStorage + browser HTTP cache so a returning user
- * cannot submit a ticker planted after their last Discover visit.
  * `/api/tokens` only indexes Robinhood — callers must only enable on that chain.
  *
- * Throws on timeout, network error, non-OK, or `unavailable` so the caller
- * can retry once then fail closed (utility over soft-open create).
+ * Throws on timeout, network error, non-OK, unavailable, or non-fresh state so
+ * the caller can retry once then fail closed (utility over soft-open create).
+ *
+ * `force` hits `/api/tokens?force=1` to bypass the server 90s TTL (submit path).
  */
-async function fetchTakenTickers(signal: AbortSignal): Promise<TakenSets> {
-  // cache: "no-store" + bust query so neither browser nor CDN soft-stale wins.
-  const res = await fetch(`/api/tokens?createCheck=${Date.now()}`, {
+async function fetchTakenTickers(
+  signal: AbortSignal,
+  opts: { force?: boolean } = {},
+): Promise<TakenKeys> {
+  const qs = new URLSearchParams();
+  qs.set("createCheck", String(Date.now()));
+  if (opts.force) qs.set("force", "1");
+  const res = await fetch(`/api/tokens?${qs.toString()}`, {
     cache: "no-store",
     signal,
   });
   if (!res.ok) throw new Error(`ticker feed HTTP ${res.status}`);
-  const json = (await res.json()) as {
-    creations?: Array<{ name?: string; symbol?: string }>;
-    unavailable?: boolean;
-  };
-  if (json.unavailable) throw new Error("ticker feed unavailable");
-  const names = new Set<string>();
-  const symbols = new Set<string>();
-  for (const c of json.creations ?? []) {
-    if (c.name) names.add(foldKey(c.name));
-    if (c.symbol) symbols.add(foldKey(c.symbol));
-  }
-  return { names, symbols };
+  const json = (await res.json()) as FeedJson;
+  return parseTakenFromFeed(json);
 }
 
 /** One timed attempt; aborts after TAKEN_FEED_TIMEOUT_MS. */
 async function fetchTakenTickersOnce(
   parentSignal?: AbortSignal,
-): Promise<TakenSets> {
+  opts: { force?: boolean } = {},
+): Promise<TakenKeys> {
   const controller = new AbortController();
   const onParentAbort = () => controller.abort();
   if (parentSignal) {
@@ -107,7 +175,7 @@ async function fetchTakenTickersOnce(
   }
   const timer = setTimeout(() => controller.abort(), TAKEN_FEED_TIMEOUT_MS);
   try {
-    return await fetchTakenTickers(controller.signal);
+    return await fetchTakenTickers(controller.signal, opts);
   } finally {
     clearTimeout(timer);
     parentSignal?.removeEventListener("abort", onParentAbort);
@@ -120,23 +188,25 @@ async function fetchTakenTickersOnce(
  */
 async function fetchTakenTickersWithRetry(
   parentSignal?: AbortSignal,
-): Promise<TakenSets> {
+  opts: { force?: boolean } = {},
+): Promise<TakenKeys> {
   let lastError: unknown;
   for (let attempt = 1; attempt <= TAKEN_FEED_MAX_ATTEMPTS; attempt++) {
     if (parentSignal?.aborted) throw new DOMException("Aborted", "AbortError");
     try {
-      return await fetchTakenTickersOnce(parentSignal);
+      return await fetchTakenTickersOnce(parentSignal, opts);
     } catch (err) {
       lastError = err;
-      // Don't retry if the page effect cleaned up (chain switch / unmount).
       if (parentSignal?.aborted) throw err;
-      // Attempt 1 failed: loop silently into attempt 2.
-      // Attempt 2 failed: fall through and rethrow.
     }
   }
   throw lastError instanceof Error
     ? lastError
     : new Error("ticker feed failed");
+}
+
+function isKeyTaken(taken: TakenKeys | null, key: string): boolean {
+  return !!taken && key.length > 0 && taken.keys.has(key);
 }
 
 const inputCls =
@@ -163,20 +233,24 @@ export default function CreatePage() {
   const [uploading, setUploading] = useState(false);
   const [uploadErr, setUploadErr] = useState("");
   // loading → ready | failed. Never open create against an empty blacklist
-  // when the feed could not be verified (timeout / network / unavailable).
+  // when the feed could not be verified (timeout / network / unavailable / stale).
   const [takenFeed, setTakenFeed] = useState<TakenFeedState>({
     status: "loading",
   });
+  /** True while submit is force-revalidating the ticker feed. */
+  const [revalidating, setRevalidating] = useState(false);
+  /** Sync lock so double-clicks cannot start two force scans / writes. */
+  const submitLockRef = useRef(false);
 
-  // Mount / chain-change: revalidate against a fresh feed for Robinhood.
-  // Attempt 1 → silent retry → fail closed (toast + force restart).
+  // Mount / chain-change: strict force revalidation (same completeness bar as
+  // submit). Attempt 1 → silent retry → fail closed (toast + force restart).
+  // Submit force-revalidates again immediately before write.
   useEffect(() => {
     if (!feedApplies) {
-      // Off Robinhood: no ticker index; don't gate create.
       setTakenFeed({
         status: "ready",
         chainId,
-        taken: { names: new Set(), symbols: new Set() },
+        taken: { keys: new Set() },
       });
       return;
     }
@@ -186,7 +260,9 @@ export default function CreatePage() {
 
     void (async () => {
       try {
-        const next = await fetchTakenTickersWithRetry(controller.signal);
+        const next = await fetchTakenTickersWithRetry(controller.signal, {
+          force: true,
+        });
         if (!cancelled) {
           setTakenFeed({ status: "ready", chainId, taken: next });
         }
@@ -237,13 +313,8 @@ export default function CreatePage() {
 
   const nameKey = foldKey(name);
   const symbolKey = foldKey(symbol);
-  const nameTaken =
-    feedApplies && !!taken && nameKey.length > 0 && taken.names.has(nameKey);
-  const symbolTaken =
-    feedApplies &&
-    !!taken &&
-    symbolKey.length > 0 &&
-    taken.symbols.has(symbolKey);
+  const nameTaken = feedApplies && isKeyTaken(taken, nameKey);
+  const symbolTaken = feedApplies && isKeyTaken(taken, symbolKey);
 
   const devBuyWei = devBuy.trim() === "" ? 0n : tryParseEther(devBuy);
   const devBuyTooLarge = devBuyWei !== undefined && devBuyWei > MAX_DEV_BUY_WEI;
@@ -273,6 +344,7 @@ export default function CreatePage() {
     !symbolTaken &&
     !waitingOnFeed &&
     !feedFailed &&
+    !revalidating &&
     devBuyWei !== undefined &&
     !devBuyTooLarge;
 
@@ -304,37 +376,66 @@ export default function CreatePage() {
     return <NotDeployed chainId={chainId} />;
   }
 
-  function onSubmit(e: FormEvent) {
+  async function onSubmit(e: FormEvent) {
     e.preventDefault();
-    if (!formValid || devBuyWei === undefined) return;
-    // Random CREATE2 salt: makes the token address unpredictable so a griefer
-    // can't pre-initialize its Uniswap pool to brick the launch.
-    const salt = bytesToHex(crypto.getRandomValues(new Uint8Array(32)));
-    const meta = {
-      imageURI: image.trim(),
-      website: website.trim(),
-      twitter: twitter.trim(),
-      telegram: telegram.trim(),
-    };
-    const common = { address: pad, abi: potatoPadAbi, value: devBuyWei } as const;
-    const trimmedName = name.trim();
-    const ticker = symbol.trim().toUpperCase();
+    if (!formValid || devBuyWei === undefined || revalidating || tx.busy) return;
+    if (submitLockRef.current) return;
+    submitLockRef.current = true;
 
-    // Both entry points launch identically — same locked LP, same treasury cut.
-    // createRewardToken additionally splits the creator half with holders.
-    if (rewardsOn) {
+    try {
+      // Pre-submit revalidation (Robinhood only): force a fresh scan so we do not
+      // plant against a mount-time or 90s-TTL snapshot. Soft-guard only — contract
+      // still does not enforce uniqueness.
+      if (feedApplies) {
+        setRevalidating(true);
+        try {
+          const next = await fetchTakenTickersWithRetry(undefined, { force: true });
+          setTakenFeed({ status: "ready", chainId, taken: next });
+          const nk = foldKey(name);
+          const sk = foldKey(symbol);
+          if (isKeyTaken(next, nk) || isKeyTaken(next, sk)) {
+            // Snapshot updated → UI shows taken; do not write.
+            return;
+          }
+        } catch {
+          setTakenFeed({ status: "failed" });
+          return;
+        } finally {
+          setRevalidating(false);
+        }
+      }
+
+      // Random CREATE2 salt: makes the token address unpredictable so a griefer
+      // can't pre-initialize its Uniswap pool to brick the launch.
+      const salt = bytesToHex(crypto.getRandomValues(new Uint8Array(32)));
+      const meta = {
+        imageURI: image.trim(),
+        website: website.trim(),
+        twitter: twitter.trim(),
+        telegram: telegram.trim(),
+      };
+      const common = { address: pad, abi: potatoPadAbi, value: devBuyWei } as const;
+      const trimmedName = name.trim();
+      const ticker = symbol.trim().toUpperCase();
+
+      // Both entry points launch identically — same locked LP, same treasury cut.
+      // createRewardToken additionally splits the creator half with holders.
+      if (rewardsOn) {
+        tx.writeContract({
+          ...common,
+          functionName: "createRewardToken",
+          args: [trimmedName, ticker, meta, salt, creatorCutPct * 100],
+        });
+        return;
+      }
       tx.writeContract({
         ...common,
-        functionName: "createRewardToken",
-        args: [trimmedName, ticker, meta, salt, creatorCutPct * 100],
+        functionName: "createToken",
+        args: [trimmedName, ticker, meta, salt],
       });
-      return;
+    } finally {
+      submitLockRef.current = false;
     }
-    tx.writeContract({
-      ...common,
-      functionName: "createToken",
-      args: [trimmedName, ticker, meta, salt],
-    });
   }
 
   const previewSrc = resolveImageUri(image);
@@ -346,16 +447,20 @@ export default function CreatePage() {
         ? "Planted"
         : feedFailed
           ? "Verification failed"
-          : waitingOnFeed
-            ? "Checking tickers…"
-            : vampBlocked
-              ? "Deployment restricted"
-              : nameTaken || symbolTaken
-                ? "Name or ticker taken"
-                : "Plant token";
+          : revalidating
+            ? "Re-checking tickers…"
+            : waitingOnFeed
+              ? "Checking tickers…"
+              : vampBlocked
+                ? "Deployment restricted"
+                : nameTaken || symbolTaken
+                  ? "Name or ticker taken"
+                  : "Plant token";
 
   const nameFieldBlocked = nameBlocked || nameTaken;
   const symbolFieldBlocked = symbolBlocked || symbolTaken;
+  const fieldsDisabled = feedFailed || revalidating;
+  const canSubmit = formValid && !tx.busy && !tx.confirmed && !revalidating;
 
   return (
     <div className="mx-auto max-w-4xl">
@@ -375,9 +480,9 @@ export default function CreatePage() {
                 Couldn&apos;t verify existing tickers
               </p>
               <p className="mt-1 text-xs text-neutral-400">
-                The name/ticker check failed twice (timeout or feed error). Plant
-                is blocked so we never ship a duplicate under a blind empty list.
-                Reload to restart the process.
+                The name/ticker check failed twice (timeout, stale, or feed error).
+                Plant is blocked so we never ship a duplicate under an unverified
+                list. Reload to restart the process.
               </p>
               <button
                 type="button"
@@ -406,7 +511,7 @@ export default function CreatePage() {
               {feedFailed && (
                 <div className="rounded-lg border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-xs text-rose-400">
                   Name/ticker verification failed. Reload the page to try again —
-                  create stays blocked until the feed is confirmed.
+                  create stays blocked until a fresh feed is confirmed.
                 </div>
               )}
 
@@ -422,11 +527,11 @@ export default function CreatePage() {
                   maxLength={48}
                   onChange={(e) => setName(e.target.value)}
                   aria-invalid={nameFieldBlocked || undefined}
-                  disabled={feedFailed}
+                  disabled={fieldsDisabled}
                 />
                 {nameTaken && (
                   <p className="mt-1 text-xs text-rose-400">
-                    That name is already deployed on-chain. Pick another.
+                    That name or ticker is already used on the pad feed. Pick another.
                   </p>
                 )}
               </div>
@@ -443,15 +548,20 @@ export default function CreatePage() {
                   maxLength={12}
                   onChange={(e) => setSymbol(e.target.value)}
                   aria-invalid={symbolFieldBlocked || undefined}
-                  disabled={feedFailed}
+                  disabled={fieldsDisabled}
                 />
                 {symbolTaken && (
                   <p className="mt-1 text-xs text-rose-400">
-                    Ticker ${symbolKey} is already deployed on-chain. Pick another.
+                    ${symbolKey || "That ticker"} is already used as a name or
+                    ticker on the pad feed. Pick another.
                   </p>
                 )}
-                {waitingOnFeed && (
-                  <p className="mt-1 text-xs text-neutral-500">Checking existing tickers…</p>
+                {(waitingOnFeed || revalidating) && (
+                  <p className="mt-1 text-xs text-neutral-500">
+                    {revalidating
+                      ? "Re-checking existing tickers before plant…"
+                      : "Checking existing tickers…"}
+                  </p>
                 )}
               </div>
 
@@ -468,13 +578,19 @@ export default function CreatePage() {
                       <span className="text-neutral-700">—</span>
                     )}
                   </div>
-                  <label className="flex flex-1 cursor-pointer items-center justify-center rounded-lg border border-neutral-800 bg-neutral-900 text-xs font-medium text-neutral-300 transition-colors hover:bg-neutral-800">
+                  <label
+                    className={`flex flex-1 items-center justify-center rounded-lg border border-neutral-800 bg-neutral-900 text-xs font-medium text-neutral-300 transition-colors ${
+                      uploading || fieldsDisabled
+                        ? "cursor-not-allowed opacity-60"
+                        : "cursor-pointer hover:bg-neutral-800"
+                    }`}
+                  >
                     {uploading ? "Uploading…" : "Upload image"}
                     <input
                       type="file"
                       accept="image/png,image/jpeg,image/gif,image/webp,image/svg+xml"
                       className="hidden"
-                      disabled={uploading || feedFailed}
+                      disabled={uploading || fieldsDisabled}
                       onChange={handleUpload}
                     />
                   </label>
@@ -496,7 +612,7 @@ export default function CreatePage() {
                     placeholder="https://x.com/…"
                     value={twitter}
                     onChange={(e) => setTwitter(e.target.value)}
-                    disabled={feedFailed}
+                    disabled={fieldsDisabled}
                   />
                 </div>
                 <div className="space-y-1.5">
@@ -509,7 +625,7 @@ export default function CreatePage() {
                     placeholder="https://t.me/…"
                     value={telegram}
                     onChange={(e) => setTelegram(e.target.value)}
-                    disabled={feedFailed}
+                    disabled={fieldsDisabled}
                   />
                 </div>
               </div>
@@ -524,7 +640,7 @@ export default function CreatePage() {
                   placeholder="https://…"
                   value={website}
                   onChange={(e) => setWebsite(e.target.value)}
-                  disabled={feedFailed}
+                  disabled={fieldsDisabled}
                 />
               </div>
 
@@ -542,7 +658,7 @@ export default function CreatePage() {
                   inputMode="decimal"
                   value={devBuy}
                   onChange={(e) => setDevBuy(e.target.value)}
-                  disabled={feedFailed}
+                  disabled={fieldsDisabled}
                 />
                 {devBuy.trim() !== "" && devBuyWei === undefined && (
                   <p className="text-xs text-rose-400">Enter a valid ETH amount.</p>
@@ -561,7 +677,7 @@ export default function CreatePage() {
                   <button
                     type="button"
                     onClick={() => setRewardsOn(false)}
-                    disabled={feedFailed}
+                    disabled={fieldsDisabled}
                     className={`rounded-lg border px-3 py-2.5 text-left transition-colors ${
                       rewardsOn
                         ? "border-neutral-800 bg-black hover:border-neutral-700"
@@ -576,7 +692,7 @@ export default function CreatePage() {
                   <button
                     type="button"
                     onClick={() => setRewardsOn(true)}
-                    disabled={feedFailed}
+                    disabled={fieldsDisabled}
                     className={`rounded-lg border px-3 py-2.5 text-left transition-colors ${
                       rewardsOn
                         ? "border-amber-500/60 bg-amber-500/10"
@@ -609,7 +725,7 @@ export default function CreatePage() {
                       value={creatorCutPct}
                       onChange={(e) => setCreatorCutPct(Number(e.target.value))}
                       className="w-full accent-amber-500"
-                      disabled={feedFailed}
+                      disabled={fieldsDisabled}
                     />
 
                     {/* Live split preview: the three ways a fee can go. */}
@@ -667,21 +783,23 @@ export default function CreatePage() {
             ) : nameTaken || symbolTaken ? (
               <div className="space-y-1.5 rounded-xl border border-rose-900/40 bg-rose-950/10 p-4">
                 <h4 className="font-mono text-xs font-bold uppercase tracking-wider text-rose-400">
-                  Existing ticker · blocked
+                  Existing name/ticker · blocked
                 </h4>
                 <p className="text-[11px] leading-relaxed text-rose-300/80">
-                  That name or ticker is already live on the pad feed. Soft-block only — the
-                  contract still does not enforce uniqueness. Pick an original.
+                  That name or ticker is already on the pad launch feed. This is a{" "}
+                  <span className="font-semibold">client-side soft-block only</span> — the contract
+                  does not enforce uniqueness. Pick an original.
                 </p>
               </div>
             ) : (
               <div className="space-y-1.5 rounded-xl border border-neutral-800/60 bg-neutral-950 p-4">
                 <h4 className="font-mono text-xs font-bold uppercase tracking-wider text-neutral-400">
-                  Anti-vampire shield · active
+                  Name checks · active
                 </h4>
                 <p className="text-[11px] leading-relaxed text-neutral-500">
-                  Names and symbols are checked against curated ancient runners and the live
-                  on-chain launch feed, so copycats can&apos;t vamp the originals.
+                  Names and symbols are checked against curated ancient runners (on-chain) and the
+                  live pad launch feed (client soft-guard). Uniqueness is not enforced by the
+                  contract.
                 </p>
               </div>
             )}
@@ -689,9 +807,9 @@ export default function CreatePage() {
             <button
               type="submit"
               form="plant-form"
-              disabled={!formValid || tx.busy || tx.confirmed}
+              disabled={!canSubmit}
               className={`w-full rounded-xl py-3.5 text-xs font-bold uppercase tracking-widest transition-all ${
-                formValid && !tx.busy && !tx.confirmed
+                canSubmit
                   ? "bg-amber-500 text-neutral-950 hover:bg-amber-400"
                   : "cursor-not-allowed border border-neutral-800 bg-neutral-900 text-neutral-600"
               }`}

--- a/web/lib/tokenFeed.ts
+++ b/web/lib/tokenFeed.ts
@@ -81,6 +81,8 @@ let cache: {
   scanCompletedAt: number;
   state: Exclude<FeedState, "unavailable">;
   expiresAt: number;
+  /** Zero failed windows — safe for create force-min-interval reuse. */
+  complete: boolean;
 } | null = null;
 
 /** Short cooldown after a cold unavailable so /api/tokens can't force full rescans. */
@@ -196,11 +198,21 @@ async function fetchVolumes(addresses: Address[]): Promise<Map<string, number>> 
 
 // Legacy pads are capped at their repoint endBlock — immutable history. Scanned
 // once and kept for the process lifetime; only the active pad is re-scanned.
+// `legacyComplete` is true only when that scan had zero failed windows — create
+// force-validation refuses to reuse an incomplete legacy history.
 let legacyTagged: PadTag[] | null = null;
+let legacyComplete = false;
 
-async function scan(): Promise<{ creations: CreationDTO[]; unavailable: boolean }> {
+type ScanResult = {
+  creations: CreationDTO[];
+  unavailable: boolean;
+  /** True only when every log window succeeded (no tolerated gaps). */
+  complete: boolean;
+};
+
+async function scan(opts: { strict?: boolean } = {}): Promise<ScanResult> {
   const pads = padDeployments(robinhoodChain.id);
-  if (pads.length === 0) return { creations: [], unavailable: false };
+  if (pads.length === 0) return { creations: [], unavailable: false, complete: true };
 
   const latest = await client.getBlockNumber();
   // The active (write) pad has no endBlock; legacy pads carry the repoint block.
@@ -208,12 +220,17 @@ async function scan(): Promise<{ creations: CreationDTO[]; unavailable: boolean 
   const activePads = pads.filter((p) => p.endBlock === undefined);
 
   let unavailable = false;
+  let windowsFailed = 0;
+  let windowsTotal = 0;
+  /** True when we reused a soft-locked legacy history that had tolerated gaps. */
+  let inheritedIncompleteLegacy = false;
 
-  // Legacy history: scan once, reuse forever. Lock the cache in only if it came
-  // back near-complete, otherwise use this round's result but retry next time.
+  // Legacy history: scan once, reuse forever for Discover. Create force/strict
+  // only reuses a fully complete legacy cache.
   let legacyRound: PadTag[];
-  if (legacyTagged !== null) {
+  if (legacyTagged !== null && (legacyComplete || !opts.strict)) {
     legacyRound = legacyTagged;
+    if (!legacyComplete) inheritedIncompleteLegacy = true;
   } else {
     const acc: PadTag[] = [];
     let failed = 0;
@@ -226,8 +243,18 @@ async function scan(): Promise<{ creations: CreationDTO[]; unavailable: boolean 
       total += r.total;
     }
     legacyRound = acc;
-    if (total === 0 || failed / total <= 0.1) legacyTagged = acc;
-    else unavailable = true; // gappy legacy scan — don't lock it in; retry next round
+    windowsFailed += failed;
+    windowsTotal += total;
+    if (total === 0 || failed === 0) {
+      legacyTagged = acc;
+      legacyComplete = true;
+    } else if (failed / total <= 0.1 && !opts.strict) {
+      // Soft path: lock near-complete history; mark incomplete for create.
+      legacyTagged = acc;
+      legacyComplete = false;
+    } else {
+      unavailable = true; // gappy legacy scan — don't lock it in; retry next round
+    }
   }
 
   // Active pad(s): always fresh.
@@ -241,8 +268,21 @@ async function scan(): Promise<{ creations: CreationDTO[]; unavailable: boolean 
       failed += r.failed;
       total += r.total;
     }
-    if (total > 0 && failed / total > MAX_FAILED_FRACTION) unavailable = true;
+    windowsFailed += failed;
+    windowsTotal += total;
+    if (opts.strict) {
+      // Create validation: any missed window means the blacklist is incomplete.
+      if (failed > 0) unavailable = true;
+    } else if (total > 0 && failed / total > MAX_FAILED_FRACTION) {
+      unavailable = true;
+    }
   }
+
+  const complete =
+    !inheritedIncompleteLegacy &&
+    !unavailable &&
+    (windowsTotal === 0 || windowsFailed === 0);
+  if (opts.strict && !complete) unavailable = true;
 
   const tagged = [...legacyRound, ...activeRound];
 
@@ -284,59 +324,126 @@ async function scan(): Promise<{ creations: CreationDTO[]; unavailable: boolean 
     });
   }
   // Enrich with 24h volume (best-effort) so the client can offer a "Recent buys" sort.
+  // Skip on strict/create scans — volumes are unrelated to name/ticker completeness
+  // and would burn the create form's 8s timeout budget.
   const creations = [...byToken.values()];
-  try {
-    const vols = await fetchVolumes(creations.map((c) => c.token));
-    for (const c of creations) c.volume24Usd = vols.get(c.token.toLowerCase()) ?? 0;
-  } catch {
-    /* leave volumes at 0 */
+  if (!opts.strict) {
+    try {
+      const vols = await fetchVolumes(creations.map((c) => c.token));
+      for (const c of creations) c.volume24Usd = vols.get(c.token.toLowerCase()) ?? 0;
+    } catch {
+      /* leave volumes at 0 */
+    }
   }
-  return { creations, unavailable };
+  return { creations, unavailable, complete: complete && !unavailable };
 }
 
 let inFlight: Promise<FeedPayload> | null = null;
+/** Separate coalescing queue for strict force scans (create validation). */
+let forceInFlight: Promise<FeedPayload> | null = null;
+
+export type LoadFeedOptions = {
+  /**
+   * Bypass the normal 90s TTL and run a new strict scan. Used by Plant create
+   * validation (`/api/tokens?force=1`). Discover omits this.
+   *
+   * Force enables **strict** completeness: any failed log window makes the
+   * payload unavailable so create never plants against a gappy blacklist.
+   * Force does **not** reuse the shared Discover cache (a concurrent soft scan
+   * must never become create's verified blacklist); concurrent force callers
+   * only coalesce via `forceInFlight`.
+   */
+  force?: boolean;
+  /**
+   * Called only when a *new* forced scan would start (after forceInFlight
+   * coalesce). Return true to reject (rate limited).
+   */
+  consumeForceQuota?: () => boolean;
+};
 
 /**
  * Cached feed getter. Always stamps a fresh `servedAt` (incl. cache hits).
  * Soft-degrades to stale/unavailable without throwing. Concurrent cold-cache
  * callers share ONE scan (in-flight coalescing).
+ *
+ * `force: true` uses a strict scan (zero tolerated gaps) for create fail-closed
+ * semantics and skips the 90s TTL / cold backoff. Force never reuses the
+ * Discover soft-cache (avoids a later soft scan overwriting a strict result).
  */
-export async function loadFeed(): Promise<FeedPayload> {
+export async function loadFeed(options: LoadFeedOptions = {}): Promise<FeedPayload> {
   const now = Date.now();
-  if (cache && cache.expiresAt > now) {
+  if (!options.force && cache && cache.expiresAt > now) {
     return stamp(cache.creations, cache.state, cache.scanCompletedAt);
   }
   // Cold failure backoff: avoid hammering RPC with full multi-pad scans.
-  if (!cache && now < unavailableUntil) {
+  // Forced create checks skip this so a recent cold failure still re-attempts.
+  if (!options.force && !cache && now < unavailableUntil) {
     return stamp([], "unavailable", 0);
   }
-  if (inFlight) return inFlight;
-  inFlight = (async () => {
+  // Force scans do not coalesce with a non-force in-flight Discover scan —
+  // they need strict completeness. They do coalesce with another force.
+  if (!options.force && inFlight) return inFlight;
+  if (options.force && forceInFlight) return forceInFlight;
+
+  // Charge force quota only when we are about to start a new expensive scan.
+  if (options.force && options.consumeForceQuota?.()) {
+    return stamp([], "unavailable", 0);
+  }
+
+  const run = async (): Promise<FeedPayload> => {
     try {
-      const result = await scan();
-      // Gappy scans: soft-degrade. Prefer warm cache as "stale" over a partial list.
+      const result = await scan({ strict: !!options.force });
+      // Gappy scans: Discover soft-degrades to stale; create force fails closed.
       if (result.unavailable) {
+        if (options.force) {
+          // Never hand create a warm incomplete list as "verified".
+          return stamp([], "unavailable", 0);
+        }
         if (cache) return stamp(cache.creations, "stale", cache.scanCompletedAt);
         unavailableUntil = Date.now() + UNAVAILABLE_COOLDOWN_MS;
         return stamp([], "unavailable", 0);
       }
       const scanCompletedAt = Date.now();
       unavailableUntil = 0;
-      cache = {
-        creations: result.creations,
-        scanCompletedAt,
-        state: "fresh",
-        expiresAt: scanCompletedAt + CACHE_TTL_MS,
-      };
+      // Force/create results never write the shared Discover cache:
+      // strict scans skip volume enrichment and would zero "Recent buys".
+      // Discover soft scans own the shared cache only.
+      if (!options.force) {
+        // Incomplete soft scan → always stale (first response AND TTL hits).
+        const state: Exclude<FeedState, "unavailable"> = result.complete
+          ? "fresh"
+          : "stale";
+        // Never demote a complete cache with an incomplete soft scan.
+        if (!(cache?.complete && !result.complete)) {
+          cache = {
+            creations: result.creations,
+            scanCompletedAt,
+            state,
+            expiresAt: scanCompletedAt + CACHE_TTL_MS,
+            complete: result.complete,
+          };
+        }
+        return stamp(result.creations, state, scanCompletedAt);
+      }
       return stamp(result.creations, "fresh", scanCompletedAt);
     } catch {
+      if (options.force) return stamp([], "unavailable", 0);
       if (cache) return stamp(cache.creations, "stale", cache.scanCompletedAt);
       unavailableUntil = Date.now() + UNAVAILABLE_COOLDOWN_MS;
       return stamp([], "unavailable", 0);
-    } finally {
-      inFlight = null;
     }
-  })();
+  };
+
+  if (options.force) {
+    forceInFlight = run().finally(() => {
+      forceInFlight = null;
+    });
+    return forceInFlight;
+  }
+
+  inFlight = run().finally(() => {
+    inFlight = null;
+  });
   return inFlight;
 }
 


### PR DESCRIPTION
## Summary

- On **Plant a Coin**, loads the on-chain launch feed (`useLaunchActivity` → cached `/api/tokens`) and blacklists names/tickers already deployed.
- Matching is case-insensitive (names lowercased, tickers uppercased to match create submit).
- Shows a clear red error under the field and blocks submit. If the feed is unavailable, we **do not** false-block creates.

Fixes #30

## Why

`createToken` does not enforce unique name/symbol on-chain, so near-duplicate tickers can ship. Soft-blocking against the existing TokenCreated set gives creators instant feedback without a contract change.

## Test plan

- [x] `cd web && npx tsc --noEmit`
- [x] `cd web && npm run build`
- [ ] Paste a known live ticker (e.g. from Discover) into Symbol → error + submit disabled
- [ ] Paste a known live name → same for Name
- [ ] Fresh name + symbol still plants normally
- [ ] With `/api/tokens` down (`unavailable`), form still accepts any name/symbol

## Attribution

Keeps the existing "Made by proofofpotato.com" footer credit.
