### PR TITLE
ChipFurnace: opt-in 25% treasury / 25% $CHIP buyback-and-burn fee split

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ A launch is a single atomic transaction — no curve, no graduation, no waiting.
 
 4. **Fees for life.** Every swap pays the pool's 1% fee to the locked position. Anyone can call `locker.collect(tokenId)` to harvest the accrued fees; they split 50/50 — the treasury's half is auto-forwarded on `collect`, and the creator claims their half with `locker.claim()`.
 
+5. **Optional: the CHIP furnace.** Deploy with `CHIP_TOKEN` set and the pad's treasury becomes a `ChipFurnace` instead of a plain address: the protocol's half of the WETH fees flows into the furnace, where a permissionless `split()` pushes 50% onward to the real treasury and parks 50% as a WETH reserve that a keeper market-buys $CHIP with and burns (the router delivers the CHIP straight to `0xdEaD`). Net split of total LP fees: **50% creator / 25% treasury / 25% CHIP buyback-and-burn**. Funds in the furnace have exactly two exits, both fixed at construction — the treasury and the burn — so the keeper controls only timing and minimum price, never destination.
+
 **Why the token address is random.** The token is deployed with `CREATE2` off a caller-supplied **random** salt, so the address is unpredictable until the transaction is public. That stops a griefer from pre-creating and mis-initializing the token's Uniswap pool to break the single-sided mint. If a candidate address is somehow already taken, the pad walks to the next one and self-heals — no launch can be permanently bricked.
 
 **Anti-snipe.** For a short window after launch (a fixed number of blocks) no non-exempt wallet may end a transfer holding more than 2% of supply, throttling bots from vacuuming the opening liquidity. After the window it becomes a complete no-op, so normal trading is never affected.
@@ -53,6 +55,7 @@ potatopad/
   contracts/                          Hardhat project (Solidity 0.8.24)
     contracts/PotatoPad.sol           launchpad: token deploy + single-sided LP mint + dev-buy
     contracts/PotatoFeeLocker.sol     permanent LP lock + 50/50 fee splitter
+    contracts/ChipFurnace.sol         optional treasury: 25% treasury / 25% $CHIP buyback-and-burn
     contracts/PotatoToken.sol         minimal fixed-supply ERC-20 (+ time-boxed anti-snipe)
     contracts/libraries/TickMath.sol  Uniswap tick math, ported to 0.8.24
     contracts/interfaces/             minimal Uniswap V3 interfaces
@@ -163,6 +166,10 @@ BASE_SEPOLIA_RPC_URL=https://sepolia.base.org
 # START_FDV_ETH=3           # launch/open fully-diluted valuation, in ETH
 # TOP_FDV_ETH=530           # range-ceiling FDV, in ETH
 # ANTI_SNIPE_BLOCKS=1200    # length of the 2% max-wallet window, in blocks
+# CHIP_TOKEN=default        # deploy the ChipFurnace: 25% treasury / 25% buyback-burn
+#                           # ("default" = $CHIP on Robinhood; or any token address)
+# SWAP_ROUTER=0x...         # furnace's SwapRouter02 (defaults per network)
+# BURNER=0x...              # furnace buyback keeper (defaults to OWNER)
 ```
 
 Deploy:
@@ -205,6 +212,7 @@ Notes:
 |---|---|---|
 | Uniswap fee tier | 1% (`POOL_FEE = 10000`) | `PotatoPad.sol` |
 | Fee split | 50% creator / 50% treasury | `PotatoPad.sol`, `PotatoFeeLocker.sol` |
+| Fee split with furnace | 50% creator / 25% treasury / 25% $CHIP buyback-burn | `ChipFurnace.sol`, `CHIP_TOKEN` env |
 | Treasury | `0xd3358b1F39A6a71911c6e33717D185F99d43e80d` | constructor arg (`scripts/deploy.ts`) |
 | Total supply | 1,000,000,000 | `PotatoPad.sol` |
 | Launch (open) FDV | ~3 ETH | constructor arg (`START_FDV_ETH`) |

--- a/contracts/.env.example
+++ b/contracts/.env.example
@@ -6,3 +6,10 @@ ETHERSCAN_API_KEY=
 # overrides (optional)
 # TREASURY=0xd3358b1F39A6a71911c6e33717D185F99d43e80d
 # GRADUATION_ETH=0.05
+
+# ChipFurnace (optional): split the protocol fee half 25% treasury / 25% CHIP
+# buyback-and-burn. "default" resolves to $CHIP on Robinhood Chain
+# (0x1e4d3243a287EDb687A4cBf2A1223dA54E8c835f); or pass any token address.
+# CHIP_TOKEN=default
+# SWAP_ROUTER=            # SwapRouter02; defaults to the per-network canonical
+# BURNER=                 # buyback keeper; defaults to OWNER

--- a/contracts/contracts/ChipFurnace.sol
+++ b/contracts/contracts/ChipFurnace.sol
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {IWETH9} from "./interfaces/IUniswapV3.sol";
+
+/// @dev SwapRouter02 — the Uniswap router actually deployed on Robinhood Chain
+///      (and modern chains generally). NOTE: unlike the original V3 SwapRouter,
+///      `ExactInputSingleParams` has NO deadline field; callers guard staleness
+///      themselves (see {ChipFurnace.buybackAndBurn}'s `deadline` arg).
+interface ISwapRouter02 {
+    struct ExactInputSingleParams {
+        address tokenIn;
+        address tokenOut;
+        uint24 fee;
+        address recipient;
+        uint256 amountIn;
+        uint256 amountOutMinimum;
+        uint160 sqrtPriceLimitX96;
+    }
+
+    function exactInputSingle(ExactInputSingleParams calldata params)
+        external
+        payable
+        returns (uint256 amountOut);
+}
+
+/// @dev Just enough of PotatoFeeLocker to pull a parked treasury balance
+///      (the locker's brick-proof fallback path) back out as ETH.
+interface IFeeLockerClaimable {
+    function claim(address asset) external returns (uint256 amount);
+}
+
+/// @title ChipFurnace
+/// @notice Splits the protocol's fee income 50/50 between the real treasury and
+///         a market buyback-and-burn of $CHIP.
+///
+///         Deployed as the `treasury` of a PotatoPad: the locker auto-pushes the
+///         protocol's half of all WETH swap fees here as native ETH on every
+///         {PotatoFeeLocker.collect}. Combined with the locker's own 50% creator
+///         share, the effective split of total LP fees becomes:
+///
+///             50% creator  /  25% treasury  /  25% $CHIP buyback-and-burn.
+///
+///         Money can only ever leave this contract on two rails, both fixed at
+///         construction: half to the immutable `treasury`, half swapped to the
+///         immutable `chip` token with the Uniswap output sent straight to the
+///         dead address. There is no withdraw, no rescue, and no owner path to
+///         any other destination — the burner keeper can only choose WHEN and
+///         at WHAT minimum price to burn, never where funds go.
+///
+///         Flow (both steps are cheap, separate cranks so {collect} stays lean):
+///         1. {split} (permissionless): halves the accumulated ETH — one half is
+///            pushed to the treasury, the other is wrapped and parked as the
+///            WETH buyback reserve.
+///         2. {buybackAndBurn} (burner-only): swaps reserve WETH -> CHIP on the
+///            CHIP/WETH pool with a caller-supplied min-out + deadline; the
+///            router sends the CHIP output directly to 0xdEaD.
+///
+///         Why is the burn keeper-gated? A permissionless swap with an open
+///         min-out is a standing sandwich invitation, and freshly-launched V3
+///         pools keep observation cardinality 1, so there is no reliable on-chain
+///         TWAP to bound it structurally. The keeper quotes off-chain and sets
+///         `minChipOut`; worst case a lazy/absent keeper just lets the reserve
+///         accumulate — it can never be redirected.
+contract ChipFurnace is ReentrancyGuard {
+    /// @notice Burn sink. Must be a normal (unspendable) address — CHIP is an
+    ///         OZ ERC20 and reverts on transfers to address(0).
+    address internal constant DEAD = 0x000000000000000000000000000000000000dEaD;
+
+    /// @notice The real protocol treasury; receives half of every {split}.
+    address public immutable treasury;
+    IWETH9 public immutable weth;
+    ISwapRouter02 public immutable router;
+    /// @notice The token bought back and burned with the other half.
+    address public immutable chip;
+    /// @notice Fee tier of the CHIP/WETH pool (pad launches use the 1% tier).
+    uint24 public immutable chipPoolFee;
+
+    /// @notice Keeper allowed to execute buybacks (and hand off the role).
+    ///         Setting it to address(0) permanently freezes buybacks: the WETH
+    ///         reserve keeps accruing but can never be spent — value is locked,
+    ///         never extractable.
+    address public burner;
+
+    event Split(uint256 toTreasury, uint256 toBuyback);
+    event ChipBurned(uint256 wethIn, uint256 chipBurned);
+    event BurnerChanged(address indexed previousBurner, address indexed newBurner);
+
+    error InvalidConfig();
+    error OnlyBurner();
+    error NothingToSplit();
+    error NothingToBurn();
+    error Expired();
+    error EthTransferFailed();
+
+    constructor(
+        address treasury_,
+        IWETH9 weth_,
+        ISwapRouter02 router_,
+        address chip_,
+        uint24 chipPoolFee_,
+        address burner_
+    ) {
+        if (
+            treasury_ == address(0) || address(weth_) == address(0) || address(router_) == address(0)
+                || chip_ == address(0) || burner_ == address(0)
+        ) revert InvalidConfig();
+        treasury = treasury_;
+        weth = weth_;
+        router = router_;
+        chip = chip_;
+        chipPoolFee = chipPoolFee_;
+        burner = burner_;
+    }
+
+    /// @dev Accepts ETH from the locker's treasury push (and anyone else who
+    ///      wants to feed the furnace). Deliberately does nothing: keeping this
+    ///      a no-op keeps {PotatoFeeLocker.collect} cheap and guarantees the
+    ///      locker's push never falls back to the claimable path in normal use.
+    receive() external payable {}
+
+    /// @notice Halves the accumulated ETH: 50% pushed to the treasury, 50%
+    ///         wrapped into the WETH buyback reserve. Permissionless — anyone
+    ///         can crank it; both destinations are fixed, so there is nothing
+    ///         a caller can influence.
+    function split() external nonReentrant returns (uint256 toTreasury, uint256 toBuyback) {
+        uint256 bal = address(this).balance;
+        if (bal == 0) revert NothingToSplit();
+        toTreasury = bal / 2;
+        toBuyback = bal - toTreasury; // odd wei goes to the burn side
+
+        weth.deposit{value: toBuyback}();
+        (bool ok,) = treasury.call{value: toTreasury}("");
+        if (!ok) revert EthTransferFailed(); // nothing moved that shouldn't; retry later
+
+        emit Split(toTreasury, toBuyback);
+    }
+
+    /// @notice Market-buys CHIP with `amountIn` of the WETH reserve (0 = the
+    ///         whole reserve) and burns it: the router delivers the CHIP
+    ///         directly to the dead address. Burner-only; `minChipOut` is the
+    ///         sandwich guard (quote off-chain, e.g. QuoterV2, minus tolerance)
+    ///         and `deadline` stops a stale signed tx from executing late.
+    function buybackAndBurn(uint256 amountIn, uint256 minChipOut, uint256 deadline)
+        external
+        nonReentrant
+        returns (uint256 chipBurned)
+    {
+        if (msg.sender != burner) revert OnlyBurner();
+        if (block.timestamp > deadline) revert Expired();
+
+        uint256 reserve = weth.balanceOf(address(this));
+        if (amountIn == 0) amountIn = reserve;
+        if (amountIn == 0 || amountIn > reserve) revert NothingToBurn();
+
+        weth.approve(address(router), amountIn);
+        chipBurned = router.exactInputSingle(
+            ISwapRouter02.ExactInputSingleParams({
+                tokenIn: address(weth),
+                tokenOut: chip,
+                fee: chipPoolFee,
+                recipient: DEAD,
+                amountIn: amountIn,
+                amountOutMinimum: minChipOut,
+                sqrtPriceLimitX96: 0
+            })
+        );
+        emit ChipBurned(amountIn, chipBurned);
+    }
+
+    /// @notice Pulls a treasury balance that a locker parked via its brick-proof
+    ///         fallback (only happens if a push to this contract ever failed).
+    ///         The locker unwraps and sends native ETH here, joining the next
+    ///         {split}. Permissionless: it can only claim THIS contract's own
+    ///         claimable balance.
+    function claimFromLocker(address locker) external nonReentrant returns (uint256 amount) {
+        amount = IFeeLockerClaimable(locker).claim(address(weth));
+    }
+
+    /// @notice Hands the burner role to `newBurner`. address(0) renounces it,
+    ///         permanently freezing buybacks (see {burner}).
+    function setBurner(address newBurner) external {
+        if (msg.sender != burner) revert OnlyBurner();
+        emit BurnerChanged(burner, newBurner);
+        burner = newBurner;
+    }
+
+    /// @notice WETH currently earmarked for buyback-and-burn.
+    function buybackReserve() external view returns (uint256) {
+        return weth.balanceOf(address(this));
+    }
+
+    /// @notice ETH received from fee collections that hasn't been {split} yet.
+    function pendingSplit() external view returns (uint256) {
+        return address(this).balance;
+    }
+}

--- a/contracts/package-lock.json
+++ b/contracts/package-lock.json
@@ -15,6 +15,7 @@
         "@nomicfoundation/hardhat-toolbox": "^5.0.0",
         "@types/mocha": "^10.0.10",
         "@types/node": "^26.1.1",
+        "@uniswap/swap-router-contracts": "^1.3.1",
         "@uniswap/v3-core": "^1.0.1",
         "@uniswap/v3-periphery": "^1.4.4",
         "dotenv": "^17.4.2",
@@ -1870,6 +1871,39 @@
       "license": "GPL-3.0-or-later",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@uniswap/swap-router-contracts": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/swap-router-contracts/-/swap-router-contracts-1.3.1.tgz",
+      "integrity": "sha512-mh/YNbwKb7Mut96VuEtL+Z5bRe0xVIbjjiryn+iMMrK2sFKhR4duk/86mEz0UO5gSx4pQIw9G5276P5heY/7Rg==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "dependencies": {
+        "@openzeppelin/contracts": "3.4.2-solc-0.7",
+        "@uniswap/v2-core": "^1.0.1",
+        "@uniswap/v3-core": "^1.0.0",
+        "@uniswap/v3-periphery": "^1.4.4",
+        "dotenv": "^14.2.0",
+        "hardhat-watcher": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@uniswap/swap-router-contracts/node_modules/@openzeppelin/contracts": {
+      "version": "3.4.2-solc-0.7",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-3.4.2-solc-0.7.tgz",
+      "integrity": "sha512-W6QmqgkADuFcTLzHL8vVoNBtkwjvQRpYIAom7KiUNoLKghyx3FgH0GBjt8NRvigV1ZmMOBllvE1By1C+bi8WpA==",
+      "dev": true
+    },
+    "node_modules/@uniswap/swap-router-contracts/node_modules/dotenv": {
+      "version": "14.3.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-14.3.2.tgz",
+      "integrity": "sha512-vwEppIphpFdvaMCaHfCEv9IgwcxMljMw2TnAQBB4VWPvzXQLTb82jwmdOKzlEVUL3gNFT4l4TPKO+Bn+sqcrVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@uniswap/v2-core": {
@@ -4442,6 +4476,54 @@
       },
       "peerDependencies": {
         "hardhat": "^2.0.2"
+      }
+    },
+    "node_modules/hardhat-watcher": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/hardhat-watcher/-/hardhat-watcher-2.5.0.tgz",
+      "integrity": "sha512-Su2qcSMIo2YO2PrmJ0/tdkf+6pSt8zf9+4URR5edMVti6+ShI8T3xhPrwugdyTOFuyj8lKHrcTZNKUFYowYiyA==",
+      "dev": true,
+      "dependencies": {
+        "chokidar": "^3.5.3"
+      },
+      "peerDependencies": {
+        "hardhat": "^2.0.0"
+      }
+    },
+    "node_modules/hardhat-watcher/node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/hardhat-watcher/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
       }
     },
     "node_modules/hardhat/node_modules/@noble/hashes": {

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -13,6 +13,7 @@
     "@nomicfoundation/hardhat-toolbox": "^5.0.0",
     "@types/mocha": "^10.0.10",
     "@types/node": "^26.1.1",
+    "@uniswap/swap-router-contracts": "^1.3.1",
     "@uniswap/v3-core": "^1.0.1",
     "@uniswap/v3-periphery": "^1.4.4",
     "dotenv": "^17.4.2",

--- a/contracts/scripts/deploy.ts
+++ b/contracts/scripts/deploy.ts
@@ -18,13 +18,20 @@ import NPMArtifact from "@uniswap/v3-periphery/artifacts/contracts/NonfungiblePo
  *   START_FDV_ETH      launch/open FDV in ETH    (default: 3   ≈ $6k)
  *   TOP_FDV_ETH        range-ceiling FDV in ETH  (default: 530 ≈ $1M)
  *   ANTI_SNIPE_BLOCKS  max-wallet (2%) window    (default: 1200 ≈ 2min at Robinhood's 0.1s blocks)
+ *   CHIP_TOKEN         enable the ChipFurnace: deploys a furnace that receives
+ *                      the protocol fee half and splits it 25% treasury /
+ *                      25% buyback-and-burn of this token. The pad's `treasury`
+ *                      is then the furnace, not TREASURY directly.
+ *   SWAP_ROUTER        SwapRouter02 used by the furnace (default: per-network canonical)
+ *   BURNER             keeper allowed to execute furnace buybacks (default: OWNER)
  */
-const CANONICAL: Record<string, { factory: string; npm: string; weth: string }> = {
+const CANONICAL: Record<string, { factory: string; npm: string; weth: string; swapRouter02?: string }> = {
   // https://developers.uniswap.org/contracts/v3/reference/deployments/base-deployments
   baseSepolia: {
     factory: "0x4752ba5DBc23f44D87826276BF6Fd6b1C372aD24",
     npm: "0x27F971cb582BF9E50F397e4d29a5C7A34f11faA2",
     weth: "0x4200000000000000000000000000000000000006",
+    swapRouter02: "0x94cC0AaC535CCDB3C01d6787D6413C739ae12bc4",
   },
   // Robinhood Chain mainnet (chainId 4663). Uniswap V3 lives at NON-canonical
   // addresses here. Every address below was triangulated + verified on-chain:
@@ -33,12 +40,18 @@ const CANONICAL: Record<string, { factory: string; npm: string; weth: string }> 
   //   - npm: from Uniswap's deployments page; its factory()/WETH9() point back
   //     to the factory + weth below (self-consistent on-chain).
   //   - weth: a live pool's token0() equals Robinhood's official docs WETH address.
+  //   - swapRouter02: the router the potato.fm frontend trades through.
   robinhoodMainnet: {
     factory: "0x1f7d7550b1b028f7571e69a784071f0205fd2efa",
     npm: "0x73991a25c818bf1f1128deaab1492d45638de0d3",
     weth: "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73",
+    swapRouter02: "0xcaf681a66d020601342297493863e78c959e5cb2",
   },
 };
+
+// $CHIP on Robinhood Chain (launched on the v2 pad; CHIP/WETH pool is the 1% tier).
+// Passed as a default so `CHIP_TOKEN=default` works; any other value overrides.
+const ROBINHOOD_CHIP = "0x1e4d3243a287EDb687A4cBf2A1223dA54E8c835f";
 
 const DEFAULT_TREASURY = "0xd3358b1F39A6a71911c6e33717D185F99d43e80d";
 
@@ -94,9 +107,32 @@ async function main() {
     throw new Error(`no Uniswap V3 addresses configured for network '${network.name}'`);
   }
 
+  // Optional ChipFurnace: when CHIP_TOKEN is set, the pad's treasury becomes a
+  // furnace that splits the protocol's fee half 50/50 — half onward to the real
+  // TREASURY, half market-buying CHIP and burning it. Net split of total LP
+  // fees: 50% creator / 25% treasury / 25% CHIP buyback-and-burn.
+  let furnace: string | undefined;
+  let padTreasury = treasury;
+  const chipEnv = process.env.CHIP_TOKEN;
+  if (chipEnv) {
+    const chip = chipEnv === "default" ? ROBINHOOD_CHIP : chipEnv;
+    const swapRouter = process.env.SWAP_ROUTER || CANONICAL[network.name]?.swapRouter02;
+    if (!swapRouter) {
+      throw new Error(`CHIP_TOKEN set but no SwapRouter02 known for '${network.name}' — set SWAP_ROUTER`);
+    }
+    const burner = process.env.BURNER || owner;
+    const furnaceC = await (
+      await ethers.getContractFactory("ChipFurnace")
+    ).deploy(treasury, weth, swapRouter, chip, 10_000, burner);
+    await furnaceC.waitForDeployment();
+    furnace = furnaceC.target as string;
+    padTreasury = furnace;
+    console.log(`ChipFurnace:     ${furnace}  (chip=${chip}, burner=${burner})`);
+  }
+
   const pad = await (
     await ethers.getContractFactory("PotatoPad")
-  ).deploy(treasury, startFdv, topFdv, antiSnipeBlocks, factory, npm, weth, owner, ANCIENT_BANNED);
+  ).deploy(padTreasury, startFdv, topFdv, antiSnipeBlocks, factory, npm, weth, owner, ANCIENT_BANNED);
   await pad.waitForDeployment();
   const locker = await pad.locker();
   const [actualStart, actualTop] = await Promise.all([pad.actualStartFdv(), pad.actualTopFdv()]);
@@ -111,6 +147,8 @@ async function main() {
     network: network.name,
     pad: pad.target,
     locker,
+    furnace: furnace ?? null,
+    padTreasury,
     treasury,
     owner,
     bannedSeed: ANCIENT_BANNED,

--- a/contracts/test/chipfurnace.test.ts
+++ b/contracts/test/chipfurnace.test.ts
@@ -1,0 +1,281 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { loadFixture, mine } from "@nomicfoundation/hardhat-toolbox/network-helpers";
+
+import FactoryArtifact from "@uniswap/v3-core/artifacts/contracts/UniswapV3Factory.sol/UniswapV3Factory.json";
+import NPMArtifact from "@uniswap/v3-periphery/artifacts/contracts/NonfungiblePositionManager.sol/NonfungiblePositionManager.json";
+import RouterArtifact from "@uniswap/v3-periphery/artifacts/contracts/SwapRouter.sol/SwapRouter.json";
+import Router02Artifact from "@uniswap/swap-router-contracts/artifacts/contracts/SwapRouter02.sol/SwapRouter02.json";
+
+const E18 = 10n ** 18n;
+const POOL_FEE = 10_000;
+const START_FDV = 3n * E18;
+const TOP_FDV = 530n * E18;
+const ANTI_SNIPE_BLOCKS = 10;
+
+const NO_META = { imageURI: "", website: "", twitter: "", telegram: "" };
+const BANNED_SEED = ["CASHCAT", "GameStop"];
+const DEAD = "0x000000000000000000000000000000000000dead";
+
+const saltFor = (s: string) => ethers.id(s);
+
+/** Real Uniswap V3 from the official artifacts, plus BOTH router generations:
+ *  the V3 SwapRouter (for simulated user trading, as in potatopad.test.ts) and
+ *  SwapRouter02 (what the furnace swaps through — the router live on Robinhood). */
+async function deployStack() {
+  const weth = await (await ethers.getContractFactory("WETH9")).deploy();
+  const v3Factory = await (await ethers.getContractFactoryFromArtifact(FactoryArtifact)).deploy();
+  const npm = await (
+    await ethers.getContractFactoryFromArtifact(NPMArtifact)
+  ).deploy(v3Factory.target, weth.target, ethers.ZeroAddress);
+  const router = await (
+    await ethers.getContractFactoryFromArtifact(RouterArtifact)
+  ).deploy(v3Factory.target, weth.target);
+  // SwapRouter02(factoryV2, factoryV3, positionManager, WETH9) — no V2 here.
+  const router02 = await (
+    await ethers.getContractFactoryFromArtifact(Router02Artifact)
+  ).deploy(ethers.ZeroAddress, v3Factory.target, npm.target, weth.target);
+  return { weth, v3Factory, npm, router, router02 };
+}
+
+/** WETH->token buy through the V3 SwapRouter (mirrors the main test file). */
+async function buy(router: any, weth: any, buyer: any, tokenAddr: string, value: bigint) {
+  const deadline = (await ethers.provider.getBlock("latest"))!.timestamp + 600;
+  return router.connect(buyer).exactInputSingle(
+    {
+      tokenIn: weth.target,
+      tokenOut: tokenAddr,
+      fee: POOL_FEE,
+      recipient: buyer.address,
+      deadline,
+      amountIn: value,
+      amountOutMinimum: 0,
+      sqrtPriceLimitX96: 0,
+    },
+    { value }
+  );
+}
+
+/**
+ * Mirrors the intended mainnet topology:
+ *   1. an older pad launches CHIP (on mainnet CHIP lives on the v2 pad),
+ *   2. a ChipFurnace is wired to CHIP + SwapRouter02,
+ *   3. a NEW pad is deployed with `treasury = furnace`,
+ *   4. a token launches on the new pad and a trader buys, accruing WETH fees.
+ */
+async function furnaceFixture() {
+  const [deployer, realTreasury, creator, alice, burner] = await ethers.getSigners();
+  const { weth, v3Factory, npm, router, router02 } = await deployStack();
+  const Pad = await ethers.getContractFactory("PotatoPad");
+  const padArgs = (treasury: string) =>
+    [treasury, START_FDV, TOP_FDV, ANTI_SNIPE_BLOCKS, v3Factory.target, npm.target, weth.target, deployer.address, BANNED_SEED] as const;
+
+  // 1. CHIP, launched on an older pad whose fees still flow 50/50 to the EOA treasury.
+  const padV2 = await Pad.deploy(...padArgs(realTreasury.address));
+  const chipAddr = await padV2.connect(creator).createToken.staticCall("Chip", "CHIP", NO_META, saltFor("chip"));
+  await padV2.connect(creator).createToken("Chip", "CHIP", NO_META, saltFor("chip"));
+  const chip = await ethers.getContractAt("PotatoToken", chipAddr);
+  // Leave CHIP's anti-snipe window so a large burn to 0xdEaD is a plain transfer.
+  await mine(ANTI_SNIPE_BLOCKS + 1);
+
+  // 2. The furnace.
+  const furnace = await (
+    await ethers.getContractFactory("ChipFurnace")
+  ).deploy(realTreasury.address, weth.target, router02.target, chipAddr, POOL_FEE, burner.address);
+
+  // 3. The new pad, with the furnace as its treasury.
+  const pad = await Pad.deploy(...padArgs(furnace.target as string));
+  const locker = await ethers.getContractAt("PotatoFeeLocker", await pad.locker());
+
+  // 4. A launch on the new pad + a 1 ETH buy (past the window so no wallet cap).
+  const memeAddr = await pad.connect(creator).createToken.staticCall("Meme", "MEME", NO_META, saltFor("meme"));
+  await pad.connect(creator).createToken("Meme", "MEME", NO_META, saltFor("meme"));
+  await mine(ANTI_SNIPE_BLOCKS + 1);
+  await buy(router, weth, alice, memeAddr, 1n * E18);
+  const memeInfo = await pad.tokens(memeAddr);
+
+  return {
+    deployer, realTreasury, creator, alice, burner,
+    weth, v3Factory, npm, router, router02,
+    padV2, chip, chipAddr, furnace, pad, locker, memeAddr, memeInfo,
+  };
+}
+
+/** furnaceFixture + fees collected, so the furnace holds the protocol's ETH half. */
+async function collectedFixture() {
+  const ctx = await furnaceFixture();
+  await ctx.locker.collect(ctx.memeInfo.lpTokenId);
+  return ctx;
+}
+
+async function swapDeadline(): Promise<number> {
+  return (await ethers.provider.getBlock("latest"))!.timestamp + 600;
+}
+
+describe("ChipFurnace (50% creator / 25% treasury / 25% CHIP buyback-and-burn)", () => {
+  describe("deployment", () => {
+    it("stores config and rejects zero addresses", async () => {
+      const { furnace, realTreasury, weth, router02, chipAddr, burner } = await loadFixture(furnaceFixture);
+      expect(await furnace.treasury()).to.equal(realTreasury.address);
+      expect(await furnace.weth()).to.equal(weth.target);
+      expect(await furnace.router()).to.equal(router02.target);
+      expect(await furnace.chip()).to.equal(chipAddr);
+      expect(await furnace.chipPoolFee()).to.equal(POOL_FEE);
+      expect(await furnace.burner()).to.equal(burner.address);
+
+      const F = await ethers.getContractFactory("ChipFurnace");
+      const args = [realTreasury.address, weth.target, router02.target, chipAddr, POOL_FEE, burner.address];
+      for (let i = 0; i < args.length - 1; i++) {
+        if (i === 4) continue; // chipPoolFee is not an address
+        const bad = [...args];
+        bad[i] = ethers.ZeroAddress;
+        await expect(F.deploy(...bad)).to.be.revertedWithCustomError(F, "InvalidConfig");
+      }
+      await expect(
+        F.deploy(realTreasury.address, weth.target, router02.target, chipAddr, POOL_FEE, ethers.ZeroAddress)
+      ).to.be.revertedWithCustomError(F, "InvalidConfig");
+    });
+  });
+
+  describe("fee flow into the furnace", () => {
+    it("collect() pushes the protocol half to the furnace as ETH (no fallback)", async () => {
+      const { locker, memeInfo, furnace, weth, creator } = await loadFixture(furnaceFixture);
+      const tx = locker.collect(memeInfo.lpTokenId);
+      await expect(tx).to.emit(locker, "TreasuryPaid");
+      await expect(tx).to.not.emit(locker, "TreasuryPayFailed");
+
+      // The furnace's ETH equals the creator's claimable WETH half (same 50/50 cut).
+      const creatorHalf = await locker.claimable(weth.target, creator.address);
+      expect(creatorHalf).to.be.gt(0n);
+      expect(await ethers.provider.getBalance(furnace.target)).to.be.closeTo(creatorHalf, 1n);
+      expect(await furnace.pendingSplit()).to.equal(await ethers.provider.getBalance(furnace.target));
+    });
+  });
+
+  describe("split", () => {
+    it("halves the balance: treasury paid in ETH, WETH reserve parked", async () => {
+      const { furnace, realTreasury, weth, alice } = await loadFixture(collectedFixture);
+      const bal = await ethers.provider.getBalance(furnace.target);
+      const toTreasury = bal / 2n;
+      const toBuyback = bal - toTreasury;
+
+      // Permissionless: a random account cranks it.
+      const tx = await furnace.connect(alice).split();
+      await expect(tx).to.emit(furnace, "Split").withArgs(toTreasury, toBuyback);
+      await expect(tx).to.changeEtherBalances([realTreasury, furnace], [toTreasury, -bal]);
+
+      expect(await weth.balanceOf(furnace.target)).to.equal(toBuyback);
+      expect(await furnace.buybackReserve()).to.equal(toBuyback);
+      expect(await furnace.pendingSplit()).to.equal(0n);
+    });
+
+    it("reverts when there is nothing to split", async () => {
+      const { furnace } = await loadFixture(furnaceFixture); // fees not collected yet
+      await expect(furnace.split()).to.be.revertedWithCustomError(furnace, "NothingToSplit");
+    });
+  });
+
+  describe("buybackAndBurn", () => {
+    it("market-buys CHIP with the whole reserve, straight into 0xdEaD", async () => {
+      const { furnace, chip, weth, burner } = await loadFixture(collectedFixture);
+      await furnace.split();
+      const reserve = await furnace.buybackReserve();
+      expect(reserve).to.be.gt(0n);
+      const deadBefore = await chip.balanceOf(DEAD);
+
+      const burned = await furnace.connect(burner).buybackAndBurn.staticCall(0n, 1n, await swapDeadline());
+      await expect(furnace.connect(burner).buybackAndBurn(0n, 1n, await swapDeadline()))
+        .to.emit(furnace, "ChipBurned").withArgs(reserve, burned);
+
+      expect(burned).to.be.gt(0n);
+      expect(await chip.balanceOf(DEAD)).to.equal(deadBefore + burned);
+      expect(await weth.balanceOf(furnace.target)).to.equal(0n);
+      // The furnace never holds CHIP — the router delivers to the sink directly.
+      expect(await chip.balanceOf(furnace.target)).to.equal(0n);
+    });
+
+    it("supports partial burns and rejects overdraw", async () => {
+      const { furnace, burner } = await loadFixture(collectedFixture);
+      await furnace.split();
+      const reserve = await furnace.buybackReserve();
+
+      await furnace.connect(burner).buybackAndBurn(reserve / 3n, 1n, await swapDeadline());
+      expect(await furnace.buybackReserve()).to.equal(reserve - reserve / 3n);
+
+      await expect(
+        furnace.connect(burner).buybackAndBurn(reserve, 1n, await swapDeadline())
+      ).to.be.revertedWithCustomError(furnace, "NothingToBurn");
+    });
+
+    it("enforces the slippage guard, the deadline, and the burner gate", async () => {
+      const { furnace, burner, alice } = await loadFixture(collectedFixture);
+      await furnace.split();
+
+      await expect(
+        furnace.connect(alice).buybackAndBurn(0n, 1n, await swapDeadline())
+      ).to.be.revertedWithCustomError(furnace, "OnlyBurner");
+      await expect(
+        furnace.connect(burner).buybackAndBurn(0n, 1n, 1)
+      ).to.be.revertedWithCustomError(furnace, "Expired");
+      await expect(
+        furnace.connect(burner).buybackAndBurn(0n, ethers.MaxUint256, await swapDeadline())
+      ).to.be.revertedWith("Too little received");
+    });
+
+    it("reverts when the reserve is empty", async () => {
+      const { furnace, burner } = await loadFixture(furnaceFixture);
+      await expect(
+        furnace.connect(burner).buybackAndBurn(0n, 1n, await swapDeadline())
+      ).to.be.revertedWithCustomError(furnace, "NothingToBurn");
+    });
+  });
+
+  describe("the net split of total WETH fees is 50/25/25", () => {
+    it("creator claim ≈ 2 × treasury payout, burn reserve ≈ treasury payout", async () => {
+      const { locker, memeInfo, furnace, realTreasury, weth, creator, deployer, router, memeAddr } =
+        await loadFixture(furnaceFixture);
+      // More volume from a second account, then harvest everything at once.
+      await buy(router, weth, deployer, memeAddr, 2n * E18);
+      await locker.collect(memeInfo.lpTokenId);
+
+      const creatorHalf = await locker.claimable(weth.target, creator.address); // 50% of WETH fees
+      const treasuryBefore = await ethers.provider.getBalance(realTreasury.address);
+      await furnace.split();
+      const treasuryDelta = (await ethers.provider.getBalance(realTreasury.address)) - treasuryBefore;
+
+      expect(treasuryDelta).to.be.closeTo(creatorHalf / 2n, 2n); // 25%
+      expect(await furnace.buybackReserve()).to.be.closeTo(creatorHalf / 2n, 2n); // 25%
+    });
+  });
+
+  describe("burner role", () => {
+    it("only the burner can hand off or renounce the role", async () => {
+      const { furnace, burner, alice, deployer } = await loadFixture(collectedFixture);
+      await expect(furnace.connect(alice).setBurner(alice.address)).to.be.revertedWithCustomError(
+        furnace,
+        "OnlyBurner"
+      );
+
+      await expect(furnace.connect(burner).setBurner(deployer.address))
+        .to.emit(furnace, "BurnerChanged").withArgs(burner.address, deployer.address);
+
+      await furnace.split();
+      await expect(
+        furnace.connect(burner).buybackAndBurn(0n, 1n, await swapDeadline())
+      ).to.be.revertedWithCustomError(furnace, "OnlyBurner");
+      await expect(furnace.connect(deployer).buybackAndBurn(0n, 1n, await swapDeadline())).to.not.be
+        .reverted;
+    });
+  });
+
+  describe("claimFromLocker", () => {
+    it("propagates the locker's NothingToClaim when no fallback balance is parked", async () => {
+      const { furnace, locker } = await loadFixture(collectedFixture);
+      // The push into the furnace always succeeds, so nothing ever parks in normal use.
+      await expect(furnace.claimFromLocker(locker.target)).to.be.revertedWithCustomError(
+        locker,
+        "NothingToClaim"
+      );
+    });
+  });
+});


### PR DESCRIPTION
## What

Adds `ChipFurnace.sol` — an **opt-in** treasury contract that changes the protocol fee split from 50% creator / 50% treasury to **50% creator / 25% treasury / 25% $CHIP buyback-and-burn**.

`PotatoPad.sol` and `PotatoFeeLocker.sol` are untouched: the furnace is simply deployed as the pad's immutable `treasury`, receiving the locker's auto-pushed protocol half like any other treasury address would.

## How it works

1. `PotatoFeeLocker.collect()` pushes the protocol's WETH-fee half (as ETH) into the furnace — unchanged behavior.
2. `split()` — permissionless crank — sends 50% onward to the real treasury and wraps 50% into a WETH buyback reserve.
3. `buybackAndBurn(amountIn, minChipOut, deadline)` — keeper-gated — market-buys CHIP on the CHIP/WETH 1% pool via SwapRouter02, with the router delivering the output **directly to `0xdEaD`** (the furnace never holds CHIP).

## Security posture

- Funds have exactly two exits, both fixed as immutables at construction: the treasury and the burn. No withdraw, no rescue, no path to any other destination — the keeper only controls timing and minimum price.
- The burn is keeper-gated because pad-launched pools keep observation cardinality 1 (no usable TWAP), so a permissionless swap with an open min-out would be a standing sandwich invitation. Worst case with an absent keeper: the reserve just accumulates, unspendable.
- `receive()` is a no-op, so `collect()` stays cheap and the locker's treasury push never falls back to the claimable path. A `claimFromLocker()` escape exists for the fallback case anyway.
- `setBurner(address(0))` renounces buybacks permanently.

## Deploy

Opt-in via env — without `CHIP_TOKEN`, deploys behave exactly as before:

```
CHIP_TOKEN=default   # $CHIP on Robinhood (0x1e4d3243a287EDb687A4cBf2A1223dA54E8c835f), or any address
SWAP_ROUTER=         # SwapRouter02; defaults per network (Robinhood: 0xcaf681a66d020601342297493863e78c959e5cb2)
BURNER=              # buyback keeper; defaults to OWNER
```

Note: `treasury` is immutable in existing pads, so this only takes effect on a fresh pad deployment (the usual repoint flow); already-launched tokens keep the 50/50 split.

## Tests

11 new tests in `test/chipfurnace.test.ts`, run against real Uniswap bytecode including genuine SwapRouter02 (`@uniswap/swap-router-contracts` added as a dev dep). The fixture reproduces the mainnet topology — CHIP launched on an older pad, a new pad pointing at the furnace — and covers the end-to-end 50/25/25 math, slippage/deadline/role guards, partial burns, and direct-to-dEaD delivery.

Full suite: **43 passing**.
