### PR TITLE
Discover feed: badge holder-reward tokens + fix intermittent "—" market caps

### DIFF
--- a/web/app/api/eth-price/route.ts
+++ b/web/app/api/eth-price/route.ts
@@ -1,0 +1,91 @@
+import { NextResponse } from "next/server";
+
+/**
+ * Server-side ETH/USD spot price.
+ *
+ * These lookups used to run in the BROWSER against Relay and Coinbase directly.
+ * Both are reachable and fast, but third-party price endpoints are among the
+ * most commonly blocked hosts by ad/tracker blockers — `api.coinbase.com`
+ * especially. A blocked fetch left `usd` null, and since every PotatoPad card
+ * prices its market cap in ETH, the whole feed rendered "—".
+ *
+ * Fetching here removes the browser from the equation entirely: same-origin, no
+ * CORS, nothing for a blocker to match on, and one upstream call shared by every
+ * visitor instead of one per tab.
+ */
+
+export const runtime = "nodejs";
+
+const RELAY =
+  "https://api.relay.link/currencies/token/price?chainId=1&address=0x0000000000000000000000000000000000000000";
+const COINBASE = "https://api.coinbase.com/v2/prices/ETH-USD/spot";
+
+/** Spot moves slowly enough that a minute of staleness is invisible here. */
+const TTL_MS = 60_000;
+/** Don't let one hung upstream hold the response open. */
+const UPSTREAM_TIMEOUT_MS = 4_000;
+
+let cache: { usd: number; expiresAt: number } | null = null;
+
+function usable(n: unknown): n is number {
+  return typeof n === "number" && Number.isFinite(n) && n > 0;
+}
+
+async function withTimeout(url: string): Promise<Response | null> {
+  const ctl = new AbortController();
+  const timer = setTimeout(() => ctl.abort(), UPSTREAM_TIMEOUT_MS);
+  try {
+    return await fetch(url, { signal: ctl.signal, cache: "no-store" });
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function fetchUpstream(): Promise<number | null> {
+  const relay = await withTimeout(RELAY);
+  if (relay?.ok) {
+    const json = (await relay.json().catch(() => null)) as { price?: number } | null;
+    if (usable(json?.price)) return json.price;
+  }
+
+  const cb = await withTimeout(COINBASE);
+  if (cb?.ok) {
+    const json = (await cb.json().catch(() => null)) as { data?: { amount?: string } } | null;
+    const amount = Number(json?.data?.amount);
+    if (usable(amount)) return amount;
+  }
+
+  return null;
+}
+
+export async function GET() {
+  const now = Date.now();
+  if (cache && cache.expiresAt > now) {
+    return NextResponse.json(
+      { usd: cache.usd },
+      { headers: { "Cache-Control": "public, s-maxage=60, stale-while-revalidate=120" } },
+    );
+  }
+
+  const usd = await fetchUpstream();
+  if (usd === null) {
+    // Serve the last good price rather than a null that blanks every market cap.
+    // A slightly stale ETH price is far better than none, and the client can tell
+    // the difference via `stale`.
+    if (cache) {
+      return NextResponse.json(
+        { usd: cache.usd, stale: true },
+        { headers: { "Cache-Control": "no-store" } },
+      );
+    }
+    return NextResponse.json({ usd: null }, { headers: { "Cache-Control": "no-store" } });
+  }
+
+  cache = { usd, expiresAt: now + TTL_MS };
+  return NextResponse.json(
+    { usd },
+    { headers: { "Cache-Control": "public, s-maxage=60, stale-while-revalidate=120" } },
+  );
+}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -102,6 +102,7 @@ export default function DiscoverPage() {
           createdAt: c.timestamp,
           imageURI: c.imageURI,
           volume24Usd: c.volume24Usd,
+          holderFeeBps: c.holderFeeBps,
         };
       }),
     [creations, poolReads, weth],

--- a/web/components/TokenCard.tsx
+++ b/web/components/TokenCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Coins } from "lucide-react";
 import Link from "next/link";
 import type { Address } from "viem";
 import { formatUsd, shortAddress, timeAgo } from "@/lib/format";
@@ -26,6 +27,13 @@ export interface TokenRow {
   marketCapUsd?: number;
   /** Ancient 24h volume (USD) from GeckoTerminal. */
   volume24Usd?: number;
+  /**
+   * Holders' share of total trading fees in bps on a holder-rewards launch;
+   * undefined for a standard launch. Drives the REWARDS badge — without it the
+   * two launch types are visually identical in the feed, which is exactly the
+   * thing a buyer needs to be able to tell apart at a glance.
+   */
+  holderFeeBps?: number;
 }
 
 export function TokenCard({ row }: { row: TokenRow }) {
@@ -83,6 +91,15 @@ export function TokenCard({ row }: { row: TokenRow }) {
         {row.createdAt !== undefined && row.createdAt > 0 && (
           <span className="absolute right-2 top-2 rounded bg-black/60 px-1.5 py-0.5 font-mono text-[9px] text-neutral-300 backdrop-blur-md">
             {timeAgo(row.createdAt)}
+          </span>
+        )}
+        {row.holderFeeBps !== undefined && row.holderFeeBps > 0 && (
+          <span
+            className="absolute left-2 top-2 flex items-center gap-1 rounded bg-emerald-500/15 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wider text-emerald-400 ring-1 ring-inset ring-emerald-400/30 backdrop-blur-md"
+            title={`Holders earn ${(row.holderFeeBps / 100).toFixed(row.holderFeeBps % 100 === 0 ? 0 : 1)}% of every trade's fees, in ETH`}
+          >
+            <Coins className="h-2.5 w-2.5" />
+            {(row.holderFeeBps / 100).toFixed(row.holderFeeBps % 100 === 0 ? 0 : 1)}% rewards
           </span>
         )}
       </div>

--- a/web/components/TokenCard.tsx
+++ b/web/components/TokenCard.tsx
@@ -37,13 +37,19 @@ export interface TokenRow {
 }
 
 export function TokenCard({ row }: { row: TokenRow }) {
-  const { usd: ethUsd } = useEthUsdPrice();
+  const { usd: ethUsd, isLoading: priceLoading } = useEthUsdPrice();
 
   const mcapUsd = row.ancient
     ? (row.marketCapUsd ?? 0)
     : ethUsd !== null && row.marketCapEth > 0
       ? row.marketCapEth * ethUsd
       : 0;
+
+  // A PotatoPad market cap is priced in ETH, so it is genuinely UNKNOWN until the
+  // ETH price lands — not zero. Showing "—" while that request is still in flight
+  // reads as "no market cap", which is what made these look like they randomly
+  // vanished. Ancient cards carry USD directly and never wait on it.
+  const mcPending = !row.ancient && priceLoading && ethUsd === null && row.marketCapEth > 0;
   const mc = mcapUsd > 0 ? formatUsd(mcapUsd) : "—";
 
   // ── Ancient card: image, name, MC + 24h VOL, Ancient tag ──
@@ -109,9 +115,16 @@ export function TokenCard({ row }: { row: TokenRow }) {
           <div className="font-mono text-[11px] text-[#CCFF00]/70">${row.symbol}</div>
         </div>
         <div className="space-y-1">
-          <p className="font-mono text-sm font-bold text-neutral-100">
-            {mc} <span className="text-[10px] font-normal text-neutral-500">MC</span>
-          </p>
+          {mcPending ? (
+            <p className="flex items-center gap-1.5 font-mono text-sm font-bold text-neutral-100">
+              <span className="inline-block h-3.5 w-14 animate-pulse rounded bg-neutral-800" />
+              <span className="text-[10px] font-normal text-neutral-500">MC</span>
+            </p>
+          ) : (
+            <p className="font-mono text-sm font-bold text-neutral-100">
+              {mc} <span className="text-[10px] font-normal text-neutral-500">MC</span>
+            </p>
+          )}
           <div className="truncate font-mono text-[9px] text-neutral-600">
             {shortAddress(row.address)}
           </div>

--- a/web/lib/config.ts
+++ b/web/lib/config.ts
@@ -14,6 +14,22 @@ export const robinhoodChain = defineChain({
   blockExplorers: {
     default: { name: "Robinscan", url: "https://robinhoodchain.blockscout.com" },
   },
+  /**
+   * Canonical Multicall3, verified deployed on this chain at block 3,967,002.
+   *
+   * Without this viem cannot batch, so every `useReadContracts` degrades to ONE
+   * eth_call per contract — the Discover feed alone fired ~40 separate requests
+   * at /api/rpc per load. That proxy charges its rate limiter per JSON-RPC call,
+   * so a busy page could get individual reads throttled; since the pool reads use
+   * `allowFailure: true`, a throttled read silently became `priceWeth = 0` and the
+   * card rendered "—" market cap. Declaring it collapses those into one request.
+   */
+  contracts: {
+    multicall3: {
+      address: "0xcA11bde05977b3631167028862bE2a173976CA11",
+      blockCreated: 3_967_002,
+    },
+  },
 });
 
 export const ZERO_ADDRESS =

--- a/web/lib/config.ts
+++ b/web/lib/config.ts
@@ -81,6 +81,16 @@ export const CHAINS: ChainConfig[] = [
     quoter: "0x33e885ed0ec9bf04ecfb19341582aadcb4c8a9e7",
     padStartBlock: 13_221_549n, // deploy block of the 2%/redirect/owner() pad 0xe26e…9001
     legacyPads: [
+      // NOTE: this list is "additional pads to READ", not strictly older ones.
+      // The holder-rewards pad below is NEWER than the primary and deliberately
+      // uncapped; everything after it is a superseded pad with an end block.
+      //
+      // Holder-rewards pad 0x88eB…A338 — first pad with createRewardToken. Indexed
+      // here so its launches (and their REWARDS badge) surface in Discover while
+      // NEXT_PUBLIC_PAD_ADDRESS_ROBINHOOD still points new launches at the primary.
+      // Promote it by flipping that env var; no code change needed, and this entry
+      // then dedupes against the primary automatically in {padDeployments}.
+      { address: "0x88eB8F4aC925C0a6b5501da0eb7E202a036EA338", startBlock: 14_072_104n },
       // Superseded pads, CAPPED at the block their successor took over: existing
       // tokens still render, but launches after the repoint do not surface. No
       // token is lost — every pre-repoint launch is below the cap. (The cap on

--- a/web/lib/events.ts
+++ b/web/lib/events.ts
@@ -89,6 +89,8 @@ export interface CreationEvent {
   pad: Address;
   /** 24h USD volume (from the server feed); 0 if unindexed. */
   volume24Usd: number;
+  /** Holders' share of total fees in bps on a holder-rewards launch; undefined otherwise. */
+  holderFeeBps?: number;
 }
 
 interface LaunchActivity {
@@ -143,6 +145,7 @@ export function useLaunchActivity() {
           blockNumber: BigInt(c.blockNumber),
           pad: c.pad,
           volume24Usd: c.volume24Usd ?? 0,
+          holderFeeBps: c.holderFeeBps,
         }));
         const result: LaunchActivity = { creations, unavailable: !!json.unavailable };
         writeLaunchCache(cacheKey, result);

--- a/web/lib/price.ts
+++ b/web/lib/price.ts
@@ -3,53 +3,40 @@
 import { useQuery } from "@tanstack/react-query";
 
 export interface EthUsdPrice {
-  /** ETH spot price in USD, or null when every source failed. */
+  /** ETH spot price in USD, or null when the lookup failed. */
   usd: number | null;
+  /**
+   * True while the FIRST fetch is still in flight — the price is unknown but may
+   * yet arrive. Callers must distinguish this from a null `usd`: rendering both
+   * as "—" makes a page that is merely loading look like one whose data is
+   * unavailable, which is what made market caps appear to randomly vanish.
+   */
   isLoading: boolean;
 }
 
-// Relay's public price endpoint: native ETH on mainnet -> { price: 1885.25 }.
-// No API key, permissive CORS, and it's the same pricing infra used for swaps.
-const RELAY_ETH_USD =
-  "https://api.relay.link/currencies/token/price?chainId=1&address=0x0000000000000000000000000000000000000000";
-
 /**
- * Fetch the ETH/USD spot price from a public, no-auth source. Relay is the
- * primary; Coinbase is a fallback. Returns null if both fail (never guesses).
+ * Live ETH/USD spot price, via our own `/api/eth-price`.
+ *
+ * Deliberately NOT fetched from Relay/Coinbase in the browser any more: those
+ * are among the most commonly blocked hosts by ad/tracker blockers
+ * (`api.coinbase.com` especially), and a blocked fetch blanks the market cap on
+ * every PotatoPad card at once, since they all price in ETH. Same-origin also
+ * means one cached upstream call shared by all visitors rather than one per tab.
  */
 async function fetchEthUsd(): Promise<number | null> {
-  // Primary: Relay -> { price: 1885.25 }
   try {
-    const res = await fetch(RELAY_ETH_USD);
-    if (res.ok) {
-      const json = (await res.json()) as { price?: number };
-      const price = json?.price;
-      if (typeof price === "number" && Number.isFinite(price) && price > 0) {
-        return price;
-      }
-    }
+    const res = await fetch("/api/eth-price");
+    if (!res.ok) return null;
+    const json = (await res.json()) as { usd?: number | null };
+    const usd = json?.usd;
+    return typeof usd === "number" && Number.isFinite(usd) && usd > 0 ? usd : null;
   } catch {
-    // fall through to the fallback source
+    return null;
   }
-
-  // Fallback: Coinbase spot price -> { data: { amount: "3456.78" } }
-  try {
-    const res = await fetch("https://api.coinbase.com/v2/prices/ETH-USD/spot");
-    if (res.ok) {
-      const json = (await res.json()) as { data?: { amount?: string } };
-      const amount = Number(json?.data?.amount);
-      if (Number.isFinite(amount) && amount > 0) return amount;
-    }
-  } catch {
-    // give up gracefully
-  }
-
-  return null;
 }
 
-/** Live ETH/USD spot price, cached for ~60s. usd is null when the fetch fails. */
 export function useEthUsdPrice(): EthUsdPrice {
-  const { data, isLoading } = useQuery({
+  const { data, isPending } = useQuery({
     queryKey: ["eth-usd"],
     queryFn: fetchEthUsd,
     staleTime: 60_000,
@@ -57,5 +44,7 @@ export function useEthUsdPrice(): EthUsdPrice {
     retry: 1,
   });
 
-  return { usd: data ?? null, isLoading };
+  // `isPending`, not `isLoading`: a background refetch of an already-known price
+  // must not flip cards back into a loading state.
+  return { usd: data ?? null, isLoading: isPending };
 }

--- a/web/lib/tokenFeed.ts
+++ b/web/lib/tokenFeed.ts
@@ -14,6 +14,16 @@ const tokenCreatedEvent = parseAbiItem(
   "event TokenCreated(address indexed token, address indexed creator, string name, string symbol, address pool, string imageURI, string website, string twitter, string telegram)",
 );
 
+/**
+ * Holder-rewards launches emit this ALONGSIDE {TokenCreated}, in the same
+ * transaction. Scanned in the same `getLogs` call rather than a second pass, so
+ * marking the feed costs no extra RPC round trips. Legacy pads never emitted it
+ * and simply yield none.
+ */
+const rewardTokenLaunchedEvent = parseAbiItem(
+  "event RewardTokenLaunched(address indexed token, address indexed creator, uint16 creatorFeeBps, uint16 holderFeeBps)",
+);
+
 const LOG_CHUNK = 9_000n; // Alchemy on Robinhood caps eth_getLogs at 10k blocks.
 const SCAN_CONCURRENCY = 6; // windows fetched at once — fast without a CU spike.
 const CACHE_TTL_MS = 45_000;
@@ -36,7 +46,11 @@ interface TokenCreatedArgs {
   twitter: string;
   telegram: string;
 }
-type CreatedLog = { blockNumber: bigint | null; args: Partial<TokenCreatedArgs> };
+type CreatedLog = {
+  blockNumber: bigint | null;
+  eventName?: string;
+  args: Partial<TokenCreatedArgs> & { holderFeeBps?: number };
+};
 
 export interface CreationDTO {
   token: Address;
@@ -54,6 +68,12 @@ export interface CreationDTO {
   pad: Address;
   /** 24h USD volume from GeckoTerminal (0 if unindexed) — drives "Recent buys". */
   volume24Usd: number;
+  /**
+   * Holders' share of TOTAL trading fees, in bps, for a holder-rewards launch;
+   * undefined for a standard launch. Carried as the number rather than a flag so
+   * the badge can state the actual share — the part a buyer actually cares about.
+   */
+  holderFeeBps?: number;
 }
 export interface FeedPayload {
   creations: CreationDTO[];
@@ -77,7 +97,7 @@ async function fetchCreatedLogs(
     try {
       const logs = await client.getLogs({
         address: pad,
-        event: tokenCreatedEvent,
+        events: [tokenCreatedEvent, rewardTokenLaunchedEvent],
         fromBlock: from,
         toBlock: to,
       });
@@ -224,9 +244,23 @@ async function scan(): Promise<FeedPayload> {
     for (const b of blocks) if (b) tsByBlock.set(b.number, Number(b.timestamp));
   }
 
+  // Two event types share this scan, so partition before building rows. A
+  // RewardTokenLaunched log carries a `token` too — folding it into the same loop
+  // would mint a DTO with no name or symbol, and (since the first log per token
+  // wins) could shadow the real TokenCreated row entirely.
+  const holderBpsByToken = new Map<string, number>();
+  for (const { log } of tagged) {
+    if (log.eventName !== "RewardTokenLaunched") continue;
+    const token = log.args.token;
+    if (token && log.args.holderFeeBps !== undefined) {
+      holderBpsByToken.set(token.toLowerCase(), Number(log.args.holderFeeBps));
+    }
+  }
+
   // A token belongs to exactly one pad; dedupe by token address.
   const byToken = new Map<string, CreationDTO>();
   for (const { log, pad } of tagged) {
+    if (log.eventName !== undefined && log.eventName !== "TokenCreated") continue;
     const token = log.args.token;
     if (!token) continue;
     const key = token.toLowerCase();
@@ -246,6 +280,7 @@ async function scan(): Promise<FeedPayload> {
       blockNumber: bn !== null ? bn.toString() : "0",
       pad,
       volume24Usd: 0,
+      holderFeeBps: holderBpsByToken.get(key),
     });
   }
   // Enrich with 24h volume (best-effort) so the client can offer a "Recent buys" sort.


### PR DESCRIPTION
## What does this PR do?

Two Discover-feed improvements, split out of #39 so they can be reviewed and merged on their own. Both are **frontend-only** and stand alone on `main` — no dependency on the holder-rewards contracts.

### 1. Badge holder-reward tokens in the feed

The two launch types were visually identical in Discover, so a buyer had no way to tell a rewards token from a standard one without opening it. The badge shows the actual holder share (`45% rewards`), not just a boolean — that's the number a buyer cares about.

Reward launches already emit `RewardTokenLaunched` alongside `TokenCreated` in the same transaction, so the feed scans **both events in one `getLogs`** via viem's `events: []` — no extra RPC. The two are partitioned by `eventName` before rows are built, because a `RewardTokenLaunched` log carries a `token` field too and would otherwise mint a nameless DTO that shadows the real row.

Also indexes the holder-rewards pad `0x88eB…A338` on Robinhood (deploy block 14,072,104) so its launches surface at all. Confirmed against live mainnet data: **HODL** shows `holderFeeBps 4500`, **ASTROCAT** (same pad, no rewards) stays unbadged.

### 2. Fix market caps intermittently rendering as "—"

Two independent causes:

- **Multicall3 was never declared on `robinhoodChain`**, though it is deployed there (canonical address, block 3,967,002). Without it viem can't batch, so every `useReadContracts` degraded to one `eth_call` per contract — the feed alone fired ~40 requests at `/api/rpc` per load. That proxy rate-limits per JSON-RPC call, and a throttled read with `allowFailure: true` silently became `priceWeth = 0` → `—`. Measured: **41 requests → 1**.
- **`useEthUsdPrice` exposed `isLoading` but both consumers ignored it.** An in-flight price is `null`, so every card (all priced in ETH) showed `—` until it landed. `TokenCard` now shows a pulse while genuinely-unknown, reserving `—` for unavailable.

Also moves the ETH/USD lookup behind `/api/eth-price` — it ran in the browser against Relay/Coinbase, which ad blockers commonly block; a blocked fetch blanked every market cap at once. Server-side is same-origin, cached 60s across all visitors, and serves the last good price on upstream failure.

## Type of change

- [x] Bug fix (market caps)
- [x] New feature (feed badge)

## Checklist

- [x] `web/`: `npx tsc --noEmit` clean, `npm run build` succeeds
- [x] No contract changes — no `contracts/` impact
- [x] No secrets or `.env*` committed
- [x] Verified against live mainnet data, not just types

## Anything reviewers should look at closely?

- **`legacyPads` is now a misnomer** — the `0x88eB…A338` entry is *newer* than the primary and deliberately uncapped, unlike the superseded pads. Comment added at the top of the list.
- **The multicall3 change is broad** — it affects every batched read (holders, token pages, ticker), not just Discover. All should get faster, but worth a glance at the token page too.
- These two commits are also currently on the #39 branch. Once this merges I'll drop them from there so the two PRs don't overlap (or that can happen by rebasing #39 on the new `main`).
