### PR TITLE
feat: creator-controlled fee redirect (setFeeRecipient) (#41)

### DIFF
--- a/contracts/contracts/PotatoFeeLocker.sol
+++ b/contracts/contracts/PotatoFeeLocker.sol
@@ -88,9 +88,10 @@ contract PotatoFeeLocker is IERC721Receiver, ReentrancyGuard {
     mapping(address => mapping(address => uint256)) public claimable;
 
     /// @notice LP tokenId => address that receives the CREATOR half of future fees.
-    ///         address(0) means "the original creator" (the default). Only the pad
-    ///         owner can change it, via {redirectFees}; it never affects the treasury
-    ///         cut, already-accrued claimable balances, or the locked principal.
+    ///         address(0) means "the original creator" (the default). Writable by the
+    ///         pad owner via {redirectFees} or by the token's creator via
+    ///         {setFeeRecipient}; last write wins. Never affects the treasury cut,
+    ///         already-accrued claimable balances, or the locked principal.
     mapping(uint256 => address) public feeRecipient;
 
     event PositionLocked(uint256 indexed tokenId, address indexed launchedToken, address indexed creator);
@@ -110,6 +111,7 @@ contract PotatoFeeLocker is IERC721Receiver, ReentrancyGuard {
     error NothingToClaim();
     error EthTransferFailed();
     error OnlyOwner();
+    error OnlyCreator();
     error InvalidRewardConfig();
 
     constructor(INonfungiblePositionManager positionManager_, IWETH9 weth_, address treasury_) {
@@ -156,9 +158,9 @@ contract PotatoFeeLocker is IERC721Receiver, ReentrancyGuard {
     }
 
     /// @dev Harvest + distribute one position's fees. Internal so {redirectFees}
-    ///      can crystallize accrued fees to the CURRENT beneficiary before it
-    ///      switches — keeping the redirect strictly future-only. The public entry
-    ///      points ({collect}, {redirectFees}) hold the reentrancy guard.
+    ///      and {setFeeRecipient} can crystallize accrued fees to the CURRENT
+    ///      beneficiary before they switch — keeping redirects strictly future-only.
+    ///      The public entry points hold the reentrancy guard.
     function _collect(uint256 tokenId) internal returns (uint256 amount0, uint256 amount1) {
         LockedPosition memory pos = positions[tokenId];
         if (pos.creator == address(0)) revert UnknownPosition();
@@ -309,6 +311,19 @@ contract PotatoFeeLocker is IERC721Receiver, ReentrancyGuard {
     function redirectFees(uint256 tokenId, address to) external nonReentrant {
         if (msg.sender != IPotatoPadOwner(pad).owner()) revert OnlyOwner();
         if (positions[tokenId].creator == address(0)) revert UnknownPosition();
+        _collect(tokenId); // crystallize accrued to the current beneficiary (future-only)
+        feeRecipient[tokenId] = to;
+        emit FeesRedirected(tokenId, to, msg.sender);
+    }
+
+    /// @notice Lets a token's creator point their FUTURE fee share at any address.
+    ///         `to == address(0)` resets to the creator. Accrued fees are crystallized
+    ///         to the current beneficiary first, so changes are strictly future-only.
+    ///         Shares the same mapping as {redirectFees}; last write wins.
+    function setFeeRecipient(uint256 tokenId, address to) external nonReentrant {
+        address creator = positions[tokenId].creator;
+        if (creator == address(0)) revert UnknownPosition();
+        if (msg.sender != creator) revert OnlyCreator();
         _collect(tokenId); // crystallize accrued to the current beneficiary (future-only)
         feeRecipient[tokenId] = to;
         emit FeesRedirected(tokenId, to, msg.sender);

--- a/contracts/contracts/PotatoFeeLocker.sol
+++ b/contracts/contracts/PotatoFeeLocker.sol
@@ -306,8 +306,10 @@ contract PotatoFeeLocker is IERC721Receiver, ReentrancyGuard {
     ///         claimable balances, or the permanently-locked principal.
     ///
     ///         NOTE: this is a genuine owner power over the creator fee STREAM (no
-    ///         inactivity gate, no creator veto). The token, its principal, and the
-    ///         treasury cut remain untouchable; renouncing the pad owner freezes it.
+    ///         inactivity gate). The creator can overwrite via {setFeeRecipient} and
+    ///         the owner can always redirect again — last write wins. The token, its
+    ///         principal, and the treasury cut remain untouchable; renouncing the
+    ///         pad owner freezes this power.
     function redirectFees(uint256 tokenId, address to) external nonReentrant {
         if (msg.sender != IPotatoPadOwner(pad).owner()) revert OnlyOwner();
         if (positions[tokenId].creator == address(0)) revert UnknownPosition();

--- a/contracts/test/curvepad.test.ts
+++ b/contracts/test/curvepad.test.ts
@@ -463,6 +463,38 @@ describe("PotatoCurvePad (single-sided-v3 curve, 100% in Uniswap, no migration)"
       await locker.collect(posId);
       expect(await locker.claimable(weth.target, alice.address)).to.be.gt(0);
     });
+
+    it("setFeeRecipient reverts UnknownPosition for an unregistered tokenId", async () => {
+      const { locker, creator } = await loadFixture(createFixture);
+      await expect(locker.connect(creator).setFeeRecipient(999999, creator.address))
+        .to.be.revertedWithCustomError(locker, "UnknownPosition");
+    });
+
+    it("setFeeRecipient reset is future-only: bob keeps accrued, new fees go to creator", async () => {
+      const ctx = await loadFixture(createFixture);
+      const { pad, locker, creator, alice, bob, tokenAddr, weth } = ctx;
+      await mine(ANTI_SNIPE + 1);
+      const posId = (await pad.curves(tokenAddr)).positionId;
+
+      // Point fees at bob, then accrue while he is the beneficiary.
+      await locker.connect(creator).setFeeRecipient(posId, bob.address);
+      await buy(ctx, alice, tokenAddr, ethers.parseEther("2"));
+      await locker.collect(posId);
+      const bobBefore = await locker.claimable(weth.target, bob.address);
+      expect(bobBefore).to.be.gt(0);
+
+      // Creator resets to address(0); crystallization leaves bob's claimables alone.
+      await locker.connect(creator).setFeeRecipient(posId, ethers.ZeroAddress);
+      expect(await locker.beneficiaryOf(posId)).to.equal(creator.address);
+      expect(await locker.claimable(weth.target, bob.address)).to.equal(bobBefore);
+      expect(await locker.claimable(weth.target, creator.address)).to.equal(0);
+
+      // Only NEW volume accrues to the creator, not bob.
+      await buy(ctx, alice, tokenAddr, ethers.parseEther("1"));
+      await locker.collect(posId);
+      expect(await locker.claimable(weth.target, bob.address)).to.equal(bobBefore);
+      expect(await locker.claimable(weth.target, creator.address)).to.be.gt(0);
+    });
   });
 
   describe("holder rewards ON the curve", () => {

--- a/contracts/test/curvepad.test.ts
+++ b/contracts/test/curvepad.test.ts
@@ -375,6 +375,94 @@ describe("PotatoCurvePad (single-sided-v3 curve, 100% in Uniswap, no migration)"
       expect(await locker.claimable(weth.target, bob.address)).to.be.gt(0);
       expect(await locker.claimable(weth.target, creator.address)).to.equal(0);
     });
+
+    it("setFeeRecipient: creator can point future fees at any wallet; non-creators cannot", async () => {
+      const ctx = await loadFixture(createFixture);
+      const { pad, locker, creator, alice, bob, tokenAddr, weth } = ctx;
+      await mine(ANTI_SNIPE + 1);
+      const posId = (await pad.curves(tokenAddr)).positionId;
+
+      // Non-creator and the prospective recipient themselves cannot set.
+      await expect(locker.connect(alice).setFeeRecipient(posId, bob.address))
+        .to.be.revertedWithCustomError(locker, "OnlyCreator");
+      await expect(locker.connect(bob).setFeeRecipient(posId, bob.address))
+        .to.be.revertedWithCustomError(locker, "OnlyCreator");
+
+      // Creator redirects FUTURE fees to bob; bob can claim them.
+      await expect(locker.connect(creator).setFeeRecipient(posId, bob.address))
+        .to.emit(locker, "FeesRedirected")
+        .withArgs(posId, bob.address, creator.address);
+      expect(await locker.beneficiaryOf(posId)).to.equal(bob.address);
+
+      await buy(ctx, alice, tokenAddr, ethers.parseEther("2"));
+      await locker.collect(posId);
+      const bobClaim = await locker.claimable(weth.target, bob.address);
+      expect(bobClaim).to.be.gt(0);
+      expect(await locker.claimable(weth.target, creator.address)).to.equal(0);
+      await expect(locker.connect(bob).claim(weth.target)).to.changeEtherBalance(bob, bobClaim);
+    });
+
+    it("setFeeRecipient is future-only: accrued fees stay with the old beneficiary", async () => {
+      const ctx = await loadFixture(createFixture);
+      const { pad, locker, creator, alice, bob, tokenAddr, weth } = ctx;
+      await mine(ANTI_SNIPE + 1);
+      const posId = (await pad.curves(tokenAddr)).positionId;
+
+      // Accrue fees while creator is still the beneficiary.
+      await buy(ctx, alice, tokenAddr, ethers.parseEther("2"));
+      await locker.collect(posId);
+      const creatorBefore = await locker.claimable(weth.target, creator.address);
+      expect(creatorBefore).to.be.gt(0);
+
+      // Creator redirects; crystallization leaves prior claimables with creator.
+      await locker.connect(creator).setFeeRecipient(posId, bob.address);
+      expect(await locker.claimable(weth.target, creator.address)).to.equal(creatorBefore);
+      expect(await locker.claimable(weth.target, bob.address)).to.equal(0);
+
+      // Only NEW volume accrues to bob.
+      await buy(ctx, alice, tokenAddr, ethers.parseEther("1"));
+      await locker.collect(posId);
+      expect(await locker.claimable(weth.target, creator.address)).to.equal(creatorBefore);
+      expect(await locker.claimable(weth.target, bob.address)).to.be.gt(0);
+    });
+
+    it("setFeeRecipient(address(0)) resets to the original creator", async () => {
+      const ctx = await loadFixture(createFixture);
+      const { pad, locker, creator, bob, tokenAddr } = ctx;
+      const posId = (await pad.curves(tokenAddr)).positionId;
+
+      await locker.connect(creator).setFeeRecipient(posId, bob.address);
+      expect(await locker.beneficiaryOf(posId)).to.equal(bob.address);
+      await locker.connect(creator).setFeeRecipient(posId, ethers.ZeroAddress);
+      expect(await locker.beneficiaryOf(posId)).to.equal(creator.address);
+    });
+
+    it("owner redirectFees and creator setFeeRecipient last-write-wins on the same mapping", async () => {
+      const ctx = await loadFixture(createFixture);
+      const { pad, locker, deployer, creator, alice, bob, tokenAddr, weth } = ctx;
+      await mine(ANTI_SNIPE + 1);
+      const posId = (await pad.curves(tokenAddr)).positionId;
+
+      // Owner first, then creator overwrites.
+      await expect(locker.redirectFees(posId, alice.address))
+        .to.emit(locker, "FeesRedirected")
+        .withArgs(posId, alice.address, deployer.address);
+      await expect(locker.connect(creator).setFeeRecipient(posId, bob.address))
+        .to.emit(locker, "FeesRedirected")
+        .withArgs(posId, bob.address, creator.address);
+      expect(await locker.beneficiaryOf(posId)).to.equal(bob.address);
+
+      // Creator first, then owner overwrites back.
+      await expect(locker.redirectFees(posId, alice.address))
+        .to.emit(locker, "FeesRedirected")
+        .withArgs(posId, alice.address, deployer.address);
+      expect(await locker.beneficiaryOf(posId)).to.equal(alice.address);
+
+      // Smoke: post-owner fees land with alice.
+      await buy(ctx, bob, tokenAddr, ethers.parseEther("1"));
+      await locker.collect(posId);
+      expect(await locker.claimable(weth.target, alice.address)).to.be.gt(0);
+    });
   });
 
   describe("holder rewards ON the curve", () => {

--- a/web/components/HarvestCard.tsx
+++ b/web/components/HarvestCard.tsx
@@ -2,13 +2,14 @@
 
 import { Coins, Leaf } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { Address } from "viem";
-import { useAccount, useReadContract } from "wagmi";
+import { getAddress, isAddress, type Address } from "viem";
+import { useAccount, useReadContract, useSimulateContract } from "wagmi";
 import { potatoFeeLockerAbi, potatoPadAbi } from "@/lib/abi";
 import { PAD_ADDRESSES, ZERO_ADDRESS } from "@/lib/config";
 import { usePad, useTx } from "@/lib/hooks";
-import { formatEth } from "@/lib/format";
+import { formatEth, shortAddress } from "@/lib/format";
 import { useAccruedFees } from "@/lib/pool";
+import { AddressChip } from "@/components/AddressChip";
 import { TxStatus } from "@/components/TxStatus";
 
 type ClaimAsset = "weth" | "token";
@@ -87,6 +88,7 @@ export function HarvestCard({
   const collectTx = useTx();
   const claimWethTx = useTx();
   const claimTokenTx = useTx();
+  const setRecipientTx = useTx();
   const accrued = useAccruedFees(lpTokenId, pool, pad);
 
   const { data: locker } = useReadContract({
@@ -99,6 +101,39 @@ export function HarvestCard({
   const lockerAddr = (locker as Address | undefined) ?? ZERO_ADDRESS;
   const lockerReady = lockerAddr !== ZERO_ADDRESS;
   const tokenReady = token !== ZERO_ADDRESS;
+  const isCreator = !!user && user.toLowerCase() === creator.toLowerCase();
+
+  // Resolved fee destination (override if set, else original creator). Present on
+  // all lockers that have feeRecipient plumbing.
+  const {
+    data: beneficiary,
+    refetch: refetchBeneficiary,
+  } = useReadContract({
+    address: lockerAddr,
+    abi: potatoFeeLockerAbi,
+    functionName: "beneficiaryOf",
+    args: [lpTokenId],
+    query: { enabled: lockerReady && lpTokenId > 0n },
+  });
+
+  // Feature-detect setFeeRecipient: legacy lockers lack the selector and
+  // simulation fails with "function does not exist". Hide the control then —
+  // no error UI for old pads. On supporting lockers the creator can dry-run a
+  // no-op reset (to address(0)).
+  const { isSuccess: supportsSetFeeRecipient } = useSimulateContract({
+    address: lockerAddr,
+    abi: potatoFeeLockerAbi,
+    functionName: "setFeeRecipient",
+    args: [lpTokenId, ZERO_ADDRESS],
+    account: user,
+    query: {
+      enabled: isCreator && lockerReady && !!user && lpTokenId > 0n,
+      retry: false,
+    },
+  });
+
+  const [destInput, setDestInput] = useState("");
+  const [destErr, setDestErr] = useState("");
 
   const {
     data: creatorClaimableWeth,
@@ -123,8 +158,6 @@ export function HarvestCard({
     args: [token, creator],
     query: { enabled: lockerReady && tokenReady },
   });
-
-  const isCreator = !!user && user.toLowerCase() === creator.toLowerCase();
 
   const claimableWeth = (creatorClaimableWeth as bigint | undefined) ?? 0n;
   const claimableToken = (creatorClaimableToken as bigint | undefined) ?? 0n;
@@ -177,11 +210,39 @@ export function HarvestCard({
     collectTx.busy ||
     claimWethTx.busy ||
     claimTokenTx.busy ||
+    setRecipientTx.busy ||
     flow.kind === "await_claimables" ||
     flow.kind === "claiming";
 
   const nothingToDo = !hasUncollected && !(isCreator && hasClaimable);
   const disabled = !lockerReady || busy || nothingToDo;
+
+  // After a successful setFeeRecipient, refresh the resolved beneficiary.
+  useEffect(() => {
+    if (setRecipientTx.confirmed) {
+      void refetchBeneficiary();
+    }
+  }, [setRecipientTx.confirmed, refetchBeneficiary]);
+
+  function saveFeeDestination() {
+    setDestErr("");
+    const raw = destInput.trim();
+    // Empty input = reset to original creator (on-chain address(0)).
+    let to: Address = ZERO_ADDRESS;
+    if (raw !== "") {
+      if (!isAddress(raw)) {
+        setDestErr("Enter a valid 0x address, or leave blank to reset.");
+        return;
+      }
+      to = getAddress(raw);
+    }
+    setRecipientTx.writeContract({
+      address: lockerAddr,
+      abi: potatoFeeLockerAbi,
+      functionName: "setFeeRecipient",
+      args: [lpTokenId, to],
+    });
+  }
 
   const writeClaim = useCallback(
     (asset: ClaimAsset, expectedCtx: FlowCtx, epoch: number) => {
@@ -432,6 +493,61 @@ export function HarvestCard({
         <TxStatus tx={claimWethTx} chainId={chainId} successLabel="Claimed your WETH fees!" />
         <TxStatus tx={claimTokenTx} chainId={chainId} successLabel={`Claimed your ${symbol} fees!`} />
       </div>
+
+      {/* Fee destination: shown for every token that has a beneficiary; edit only
+          for the creator on lockers that support setFeeRecipient (feature-detected). */}
+      {beneficiary !== undefined && (
+        <div className="mt-3 rounded-lg border border-neutral-800 bg-neutral-950 p-3">
+          <p className="text-xs text-neutral-500">Fee destination</p>
+          <div className="mt-1 flex flex-wrap items-center gap-2">
+            <AddressChip address={beneficiary as string} chainId={chainId} />
+            {(beneficiary as string).toLowerCase() === creator.toLowerCase() ? (
+              <span className="text-[11px] text-neutral-600">creator wallet</span>
+            ) : (
+              <span className="text-[11px] text-neutral-600">
+                redirected from {shortAddress(creator)}
+              </span>
+            )}
+          </div>
+
+          {isCreator && supportsSetFeeRecipient && (
+            <div className="mt-3 border-t border-neutral-900 pt-3">
+              <p className="text-[11px] text-neutral-600">
+                Point future fees at any wallet (community, buyback, charity). Accrued
+                fees stay with the current destination; only future fees move. Leave
+                blank and save to reset to your creator wallet.
+              </p>
+              <div className="mt-2 flex gap-2">
+                <input
+                  type="text"
+                  value={destInput}
+                  onChange={(e) => {
+                    setDestInput(e.target.value);
+                    setDestErr("");
+                  }}
+                  placeholder="0x… or blank to reset"
+                  spellCheck={false}
+                  className="min-w-0 flex-1 rounded-lg border border-neutral-800 bg-black px-2.5 py-1.5 font-mono text-xs text-neutral-100 placeholder-neutral-700 outline-none focus:border-neutral-600"
+                />
+                <button
+                  type="button"
+                  className="btn-secondary shrink-0 px-3 py-1.5 text-xs"
+                  disabled={busy || !lockerReady}
+                  onClick={saveFeeDestination}
+                >
+                  {setRecipientTx.busy ? "Saving…" : "Save"}
+                </button>
+              </div>
+              {destErr && <p className="mt-1.5 text-[11px] text-red-400">{destErr}</p>}
+              <TxStatus
+                tx={setRecipientTx}
+                chainId={chainId}
+                successLabel="Fee destination updated. Future fees will go there."
+              />
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/web/lib/abi.ts
+++ b/web/lib/abi.ts
@@ -2308,6 +2308,11 @@ export const potatoFeeLockerAbi = [
   },
   {
     "inputs": [],
+    "name": "OnlyCreator",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "OnlyOwner",
     "type": "error"
   },
@@ -2641,6 +2646,40 @@ export const potatoFeeLockerAbi = [
     "inputs": [
       {
         "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "collectAndClaim",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "collected0",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "collected1",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "paid0",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "paid1",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
         "name": "",
         "type": "uint256"
       }
@@ -2818,6 +2857,24 @@ export const potatoFeeLockerAbi = [
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "setFeeRecipient",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {


### PR DESCRIPTION
## Summary

Closes #41.

Creators can point their **future** creator-fee share at any address via `PotatoFeeLocker.setFeeRecipient`, self-service. The pad owner keeps `redirectFees`. No change to the 50/50 split, treasury path, or burn.

### Contracts
- `setFeeRecipient(tokenId, to)` — creator-only, `nonReentrant`, crystallizes via `_collect` first (future-only), writes `feeRecipient`, emits `FeesRedirected(tokenId, to, msg.sender)`.
- New error `OnlyCreator()`.
- Reuses existing public `beneficiaryOf` (already present; no new view).
- `redirectFees` unchanged (docstring corrected to last-write-wins with creator `setFeeRecipient`).

### Tests (`curvepad.test.ts`)
- Creator sets recipient → future fees claimable by new wallet.
- Non-creator / recipient themselves revert `OnlyCreator`.
- Crystallization: pre-redirect claimables stay with old beneficiary.
- `to = address(0)` resets to original creator.
- Reset crystallization: bob keeps accrued after reset; new volume goes to creator.
- Unregistered tokenId reverts `UnknownPosition`.
- Owner ↔ creator last-write-wins on the same mapping; both emit correctly.

### Frontend
- `HarvestCard`: shows current fee destination; creator-only input+save when the locker supports `setFeeRecipient` (simulated capability check — hidden on legacy lockers).
- ABI regenerated via `scripts/sync-abi.ts`.

## Test run

```
npx hardhat test
  105 passing (1s)
```

Baseline on clean `upstream/main` before changes: **99 passing**. This PR adds 6 creator-redirect cases in the curve suite.

## Deployment note

The locker is immutable and bound to its pad at construction (`pad = msg.sender`). This only takes effect on the **next** pad+locker deploy. The UI feature-detects so existing mainnet lockers keep working without the edit control. Frontend already has multi-pad / `legacyPads` support.

## Design choice (precedence)

Both `redirectFees` (owner) and `setFeeRecipient` (creator) write the same `feeRecipient` mapping; **last write wins**. Owner moderation remains available after any creator change. Honest trade-off: a compromised creator can re-redirect after an owner intervention. An `ownerLocked` flag (set by `redirectFees`, blocks the creator setter) is a small follow-up if that edge case matters; not implemented here. **Please confirm last-write-wins is acceptable** (creator can overwrite an owner redirect; owner retains final say by redirecting again) — the `redirectFees` docstring was corrected to match this behavior.

ABI regen via `scripts/sync-abi.ts` also picks up pre-existing `collectAndClaim` drift in `web/lib/abi.ts`.
